### PR TITLE
fix(plugin-cert): test, and fail fast if need, openshift-tests on extractor

### DIFF
--- a/openshift-provider-cert
+++ b/openshift-provider-cert
@@ -311,7 +311,7 @@ cmd_results() {
         exit 1
     fi
     log_info "#> Reading results from file ${file_path}"
-    ${CMD_SONOBUOY} results -n "${NAMESPACE:-${DEFAULT_NAMESPACE}}" "${file_path}"
+    ${CMD_SONOBUOY} results "${file_path}"
 }
 
 

--- a/openshift-provider-cert
+++ b/openshift-provider-cert
@@ -311,7 +311,7 @@ cmd_results() {
         exit 1
     fi
     log_info "#> Reading results from file ${file_path}"
-    ${CMD_SONOBUOY} results "${file_path}"
+    ${CMD_SONOBUOY} results -n "${NAMESPACE:-${DEFAULT_NAMESPACE}}" "${file_path}"
 }
 
 

--- a/tools/openshift-provider-cert-plugin/executor.sh
+++ b/tools/openshift-provider-cert-plugin/executor.sh
@@ -44,12 +44,7 @@ elif [[ -n "${CERT_TEST_FILE:-}" ]]; then
     else
         os_log_info "the file provided has no tests. Sending progress and finish executor...";
         echo "(0/0/0)" > "${RESULTS_PIPE}"
-
-        res_file="${RESULTS_DIR}/junit_empty_e2e_$(date +%Y%m%d-%H%M%S).xml"
-        os_log_info "Creating empty Junit result file [${res_file}]"
-        cat << EOF > "${res_file}"
-<testsuite name="openshift-tests" tests="1" skipped="0" failures="0" time="1.0"><property name="TestVersion" value="v4.1.0-4964-g555da83"></property><testcase name="[conformance] empty test list: ${CERT_TEST_FILE} has no tests to run" time="1.0"></testcase></testsuite>
-EOF
+        create_junit_with_msg "empty" "[conformance] empty test list: ${CERT_TEST_FILE} has no tests to run"
     fi
 
 # Filter by string pattern from 'all' tests

--- a/tools/openshift-provider-cert-plugin/runner.sh
+++ b/tools/openshift-provider-cert-plugin/runner.sh
@@ -37,12 +37,7 @@ sig_handler_save_results() {
     # Create failed junit result file to avoid failures on report.
     # It could happened when executor has crashed.
     if [[ -z "${junit_output}" ]]; then
-        local res_file
-        res_file="junit_failed_e2e_$(date +%Y%m%d-%H%M%S).xml"
-        os_log_info_local "Creating failed Junit result file [${res_file}]"
-        cat << EOF > "${res_file}"
-<testsuite name="openshift-tests" tests="1" skipped="0" failures="1" time="1.0"><property name="TestVersion" value="v4.1.0-4964-g555da83"></property><testcase name="[conformance] fallback error: possible that openshift-tests has crashed" time="1.0"><failure message="">errors</failure><system-out>stdout</system-out></testcase></testsuite>
-EOF
+        create_junit_with_msg "failed" "[conformance] fallback error: possible that openshift-tests has crashed"
         junit_output=$(ls junit*.xml);
     fi
 


### PR DESCRIPTION
Check `openshift-tests` utility after extractor. It will fail fast when is unable to download from image-registry.
The image registry is required for the environment work, and it is mapped to be checked on the CLI (the `run` will not run if there's no registry deployed on the cluster[1])

Related to:
- https://issues.redhat.com/browse/SPLAT-598

References:
- [1] https://issues.redhat.com/browse/SPLAT-603

Blocked by:
- [x] https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/2
- [x] https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/3 (could be not required, but developed with that change)

