### PR TITLE
feat(plugin-cert): exposing E2E_PARALLEL var to be used externally

### DIFF
--- a/tools/openshift-provider-cert-plugin/executor.sh
+++ b/tools/openshift-provider-cert-plugin/executor.sh
@@ -24,12 +24,15 @@ os_log_info "[executor] Executor started. Choosing execution type based on envir
 
 if [[ -n "${CERT_TEST_SUITE}" ]]; then
     os_log_info "Running openshift-tests suite [${CERT_TEST_SUITE}] Provider Conformance..."
+    set +x
     openshift-tests run \
+        --max-parallel-tests "${CERT_TEST_PARALLEL}" \
         --junit-dir "${RESULTS_DIR}" \
         "${CERT_TEST_SUITE}" \
         | tee -a "${RESULTS_PIPE}" || true
 
     os_log_info "openshift-tests finished[$?]"
+    set -x
 
 # To run custom tests, set the environment CERT_LEVEL on plugin definition.
 # To generate the test file, use the script hack/generate-tests-tiers.sh

--- a/tools/openshift-provider-cert-plugin/global_env.sh
+++ b/tools/openshift-provider-cert-plugin/global_env.sh
@@ -2,7 +2,6 @@
 
 declare -gx PLUGIN_NAME
 declare -gx PLUGIN_BLOCKED_BY
-PLUGIN_BLOCKED_BY=()
 
 declare -grx CERT_TESTS_DIR="./tests/${OPENSHIFT_VERSION:-"v4.10"}"
 
@@ -10,12 +9,14 @@ declare -gx CERT_LEVEL
 declare -gx CERT_TEST_FILE
 declare -gx CERT_TEST_COUNT
 declare -gx CERT_TEST_SUITE
+declare -gx CERT_TEST_PARALLEL
 
 declare -gAx PROGRESS
 declare -grx PROGRESS_URL="http://127.0.0.1:8099/progress"
 declare -grx SONOBUOY_BIN="./sonobuoy"
 declare -grx STATUS_FILE="/tmp/sonobuoy-status.json"
 declare -grx STATUS_UPDATE_INTERVAL_SEC="5"
+declare -grx E2E_PARALLEL_DEFAULT=0
 
 declare -grx RESULTS_DIR="${RESULTS_DIR:-/tmp/sonobuoy/results}"
 declare -grx RESULTS_DONE_NOTIFY="${RESULTS_DIR}/done"
@@ -29,3 +30,9 @@ declare -grx SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 declare -grx UTIL_OTESTS_BIN="/usr/bin/openshift-tests"
 declare -grx UTIL_OTESTS_READY="${RESULTS_DIR}/openshift-tests.ready"
+
+# Defaults
+CERT_TEST_FILE=""
+CERT_TEST_SUITE=""
+CERT_TEST_COUNT=0
+CERT_TEST_PARALLEL=${E2E_PARALLEL:-${E2E_PARALLEL_DEFAULT}}

--- a/tools/openshift-provider-cert-plugin/global_fn.sh
+++ b/tools/openshift-provider-cert-plugin/global_fn.sh
@@ -28,34 +28,29 @@ init_config() {
     then
         os_log_info_local "Empty CERT_LEVEL. It should be defined. Exiting..."
         exit 1
+    fi
 
     os_log_info_local "Setting config for CERT_LEVEL=[${CERT_LEVEL:-}]..."
-    elif [[ "${CERT_LEVEL:-}" == "0" ]]
+    if [[ "${CERT_LEVEL:-}" == "0" ]]
     then
         PLUGIN_NAME="openshift-kube-conformance"
-        CERT_TEST_FILE=""
         CERT_TEST_SUITE="kubernetes/conformance"
         PLUGIN_BLOCKED_BY=()
 
     elif [[ "${CERT_LEVEL:-}" == "1" ]]
     then
         PLUGIN_NAME="openshift-conformance-validated"
-        CERT_TEST_FILE=""
         CERT_TEST_SUITE="openshift/conformance"
         PLUGIN_BLOCKED_BY+=("openshift-kube-conformance")
 
     elif [[ "${CERT_LEVEL:-}" == "2" ]]
     then
         PLUGIN_NAME="openshift-provider-cert-level2"
-        CERT_TEST_FILE=""
-        CERT_TEST_SUITE=""
         PLUGIN_BLOCKED_BY+=("openshift-conformance-validated")
 
     elif [[ "${CERT_LEVEL:-}" == "3" ]]
     then
         PLUGIN_NAME="openshift-provider-cert-level3"
-        CERT_TEST_FILE=""
-        CERT_TEST_SUITE=""
         PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level2")
 
     else
@@ -70,8 +65,21 @@ init_config() {
 }
 export -f init_config
 
+show_config() {
+    cat <<-EOF
+#> Config Dump [start] <#
+PLUGIN_NAME=${PLUGIN_NAME}
+PLUGIN_BLOCKED_BY=${PLUGIN_BLOCKED_BY[*]}
+CERT_LEVEL=${CERT_LEVEL}
+CERT_TEST_SUITE=${CERT_TEST_SUITE}
+CERT_TEST_COUNT=${CERT_TEST_COUNT}
+CERT_TEST_PARALLEL=${CERT_TEST_PARALLEL}
+RESULTS_DIR=${RESULTS_DIR}
+#> Config Dump [end] <#
+EOF
+}
+
 update_config() {
-    export CERT_TEST_COUNT=0
     if [[ -n "${CERT_TEST_FILE:-}" ]]; then
         CERT_TEST_COUNT="$(wc -l "${CERT_TEST_FILE}" |cut -f 1 -d' ' |tr -d '\n')"
     fi

--- a/tools/openshift-provider-cert-plugin/runner.sh
+++ b/tools/openshift-provider-cert-plugin/runner.sh
@@ -63,6 +63,7 @@ start_utils_extractor &
 
 os_log_info_local "initializing plugin config..."
 init_config
+show_config
 
 os_log_info_local "check and wait for dependencies..."
 wait_status_file


### PR DESCRIPTION
That change comes from discussions and research about modifying openshift-tests[1].
We can see we modify the parallelism we can take more control of the total resources allocated to the environment, on the other hand, it will impact the total execution time.

This PR will allow changing this value externally, but not implementing anything on CLI or setting on the manifest as we need to understand the good value, or if needs to be set when running in the non-dedicated environment[2].

[1] https://coreos.slack.com/archives/C02DSMAP4LA/p1654727293626179?thread_ts=1654262916.956689&cid=C02DSMAP4LA
[2] https://issues.redhat.com/browse/SPLAT-622

```
$ ./openshift-tests run --help
      --max-parallel-tests int   Maximum number of tests running in parallel. 0 defaults to test suite recommended value, which is different in each suite.
```