### PR TITLE
fix(plugin-cert): extractor run once and share the openshift-tests

### DIFF
--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -25,7 +25,7 @@ os_log_info "[executor] Executor started. Choosing execution type based on envir
 if [[ -n "${CERT_TEST_SUITE}" ]]; then
     os_log_info "Running openshift-tests suite [${CERT_TEST_SUITE}] Provider Conformance..."
     set -x
-    openshift-tests run \
+    ${UTIL_OTESTS_BIN} run \
         --max-parallel-tests "${CERT_TEST_PARALLEL}" \
         --junit-dir "${RESULTS_DIR}" \
         "${CERT_TEST_SUITE}" \
@@ -39,7 +39,7 @@ if [[ -n "${CERT_TEST_SUITE}" ]]; then
 elif [[ -n "${CERT_TEST_FILE:-}" ]]; then
     os_log_info "Running openshift-tests for custom tests [${CERT_TEST_FILE}]..."
     if [[ -s ${CERT_TEST_FILE} ]]; then
-        openshift-tests run \
+        ${UTIL_OTESTS_BIN} run \
             --junit-dir "${RESULTS_DIR}" \
             -f "${CERT_TEST_FILE}" \
             | tee -a "${RESULTS_PIPE}" || true
@@ -53,9 +53,9 @@ elif [[ -n "${CERT_TEST_FILE:-}" ]]; then
 # Filter by string pattern from 'all' tests
 elif [[ -n "${CUSTOM_TEST_FILTER_STR:-}" ]]; then
     os_log_info "Generating a filter [${CUSTOM_TEST_FILTER_STR}]..."
-    openshift-tests run --dry-run all \
+    ${UTIL_OTESTS_BIN} run --dry-run all \
         | grep "${CUSTOM_TEST_FILTER_STR}" \
-        | openshift-tests run -f - \
+        | ${UTIL_OTESTS_BIN} run -f - \
         | tee -a "${RESULTS_PIPE}" || true
 
 # Default execution - running default suite.
@@ -67,7 +67,7 @@ else
     # - Save the stdout to a custom file
     # - Create a custom Junit file w/ failed test, and details about the
     #   failures. Maybe the entire b64 of stdout as failure description field.
-    openshift-tests run \
+    ${UTIL_OTESTS_BIN} run \
         --junit-dir "${RESULTS_DIR}" \
         "${suite}" \
         | tee -a "${RESULTS_PIPE}" || true

--- a/openshift-tests-provider-cert/plugin/global_env.sh
+++ b/openshift-tests-provider-cert/plugin/global_env.sh
@@ -28,7 +28,7 @@ declare -grx KUBE_API_INT="https://172.30.0.1:443"
 declare -grx SA_CA_PATH="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 declare -grx SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 
-declare -grx UTIL_OTESTS_BIN="/usr/bin/openshift-tests"
+declare -grx UTIL_OTESTS_BIN="${RESULTS_DIR}/openshift-tests"
 declare -grx UTIL_OTESTS_READY="${RESULTS_DIR}/openshift-tests.ready"
 
 # Defaults

--- a/openshift-tests-provider-cert/plugin/global_fn.sh
+++ b/openshift-tests-provider-cert/plugin/global_fn.sh
@@ -85,7 +85,7 @@ update_config() {
     fi
     if [[ "${CERT_TEST_SUITE:-}" != "" ]]
     then
-        CERT_TEST_COUNT="$(openshift-tests run --dry-run "${CERT_TEST_SUITE}" | wc -l)"
+        CERT_TEST_COUNT="$(${UTIL_OTESTS_BIN} run --dry-run "${CERT_TEST_SUITE}" | wc -l)"
     fi
     os_log_info_local "Total tests was found: [${CERT_TEST_COUNT}]"
 }
@@ -139,6 +139,7 @@ create_junit_with_msg() {
 </testcase>
 </testsuite>
 EOF
+    chmod 644 "${junit_file}"
 }
 export -f create_junit_with_msg
 
@@ -158,7 +159,7 @@ start_utils_extractor() {
     oc image extract \
         image-registry.openshift-image-registry.svc:5000/openshift/tests:latest \
         --insecure=true \
-        --file="${UTIL_OTESTS_BIN}"
+        --file="/usr/bin/openshift-tests"
 
     os_log_info_local "[utils_extractor] check if it was downloaded"
     if [[ ! -f ${util_otests} ]]; then

--- a/openshift-tests-provider-cert/plugin/report-progress.sh
+++ b/openshift-tests-provider-cert/plugin/report-progress.sh
@@ -22,7 +22,6 @@ os_log_info_local() {
 }
 
 openshift_login
-start_utils_extractor &
 init_config
 wait_utils_extractor
 update_config


### PR DESCRIPTION
Fix blocker https://issues.redhat.com/browse/SPLAT-627
Using shared volume to store `openshift-tests` utility and avoid extracting on each container. The extractor will be on the plugin container, and the dependencies will be blocked waiting for it (normal flow).

