### PR TITLE
fix(provider-cert): imrprove file handler signals to inter container communication

### DIFF
--- a/openshift-tests-provider-cert/plugin/global_env.sh
+++ b/openshift-tests-provider-cert/plugin/global_env.sh
@@ -21,6 +21,7 @@ declare -grx E2E_PARALLEL_DEFAULT=0
 
 declare -grx RESULTS_DIR="${RESULTS_DIR:-/tmp/sonobuoy/results}"
 declare -grx RESULTS_DONE_NOTIFY="${RESULTS_DIR}/done"
+declare -grx PLUGIN_DONE_NOTIFY="${SHARED_DIR}/plugin.done"
 declare -grx RESULTS_PIPE="${SHARED_DIR}/status_pipe"
 declare -grx RESULTS_SCRIPTS="${SHARED_DIR}/plugin-scripts"
 
@@ -31,6 +32,7 @@ declare -grx SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 declare -grx UTIL_OTESTS_BIN="${SHARED_DIR}/openshift-tests"
 declare -grx UTIL_OTESTS_READY="${SHARED_DIR}/openshift-tests.ready"
+declare -grx UTIL_OTESTS_FAILED="${SHARED_DIR}/openshift-tests.failed"
 
 # Defaults
 CERT_TEST_FILE=""

--- a/openshift-tests-provider-cert/plugin/global_fn.sh
+++ b/openshift-tests-provider-cert/plugin/global_fn.sh
@@ -187,6 +187,7 @@ start_utils_extractor() {
     os_log_info_local "[extractor_start] check if it was downloaded"
     if [[ ! -f ${util_otests} ]]; then
         create_junit_with_msg "fail" "[fail][preflight] unable to extract openshift-tests utility. Check if image-registry is present."
+        touch "${UTIL_OTESTS_FAILED}"
         exit 1
     fi
     chmod u+x ${util_otests}
@@ -197,6 +198,7 @@ start_utils_extractor() {
     os_log_info_local "[extractor_start] set exec permissions for ${UTIL_OTESTS_BIN}"
     if [[ ! -x ${UTIL_OTESTS_BIN} ]]; then
         create_junit_with_msg "fail" "[fail][preflight] unable to make ${UTIL_OTESTS_BIN} executable."
+        touch "${UTIL_OTESTS_FAILED}"
         exit 1
     fi
 
@@ -204,6 +206,7 @@ start_utils_extractor() {
     tt_tests=$(${UTIL_OTESTS_BIN} run all --dry-run | wc -l)
     if [[ ${tt_tests} -le 0 ]]; then
         create_junit_with_msg "fail" "[fail][preflight] failed to get tests from ${UTIL_OTESTS_BIN} utility. Found [${tt_tests}] tests."
+        touch "${UTIL_OTESTS_FAILED}"
         exit 1
     fi
     os_log_info_local "[extractor_start] Success! openshift-tests has [${tt_tests}] tests available."
@@ -219,8 +222,9 @@ wait_utils_extractor() {
     os_log_info_local "[extractor_wait] waiting for utils_extractor()"
     while true;
     do
-        os_log_info_local "[extractor_wait] Check file exists=[${UTIL_OTESTS_READY}]"
+        os_log_info_local "[extractor_wait] Check files exists=[${UTIL_OTESTS_READY} ${UTIL_OTESTS_FAILED}]"
         test -f "${UTIL_OTESTS_READY}" && break
+        test -f "${UTIL_OTESTS_FAILED}" && exit 1
         sleep "${STATUS_UPDATE_INTERVAL_SEC}"
     done
     os_log_info_local "[extractor_wait] finished!"

--- a/openshift-tests-provider-cert/plugin/report-progress.sh
+++ b/openshift-tests-provider-cert/plugin/report-progress.sh
@@ -67,7 +67,7 @@ wait_pipe_exists() {
 watch_plugin_done() {
     os_log_info_local "waiting for plugin done file..."
     while true; do
-        if [[ -f "${RESULTS_DONE_NOTIFY}" ]]
+        if [[ -f "${PLUGIN_DONE_NOTIFY}" ]]
         then
             echo "Sonobuoy done detected [done wacther]" |tee -a "${RESULTS_PIPE}"
             return
@@ -88,7 +88,7 @@ watch_dependency_done() {
         last_count=0
         while true;
         do
-            if [[ -f "${RESULTS_DONE_NOTIFY}" ]]
+            if [[ -f "${PLUGIN_DONE_NOTIFY}" ]]
             then
                 echo "[watch_dependency] Done file detected" |tee -a "${RESULTS_PIPE}"
                 return
@@ -164,7 +164,7 @@ report_progress() {
     while true
     do
         # Watch sonobuoy done file
-        if [[ -f "${RESULTS_DONE_NOTIFY}" ]]
+        if [[ -f "${PLUGIN_DONE_NOTIFY}" ]]
         then
             echo "[report_progress] Done file detected"
             break

--- a/openshift-tests-provider-cert/plugin/runner.sh
+++ b/openshift-tests-provider-cert/plugin/runner.sh
@@ -44,6 +44,9 @@ sig_handler_save_results() {
     os_log_info_local "Adjusting permissions for results files."
     chmod 644 "${junit_output}";
 
+    os_log_info_local "Sending plugin done to unlock report-progress"
+    touch "${PLUGIN_DONE_NOTIFY}"
+
     os_log_info_local "Sending sonobuoy worker the result file path"
     echo "${RESULTS_DIR}/${junit_output}" > "${RESULTS_DONE_NOTIFY}"
 


### PR DESCRIPTION
Improve container signal file handlers:
- fix: adding `plugin.done` signal to `report-progress` container correctly know when the plugin has finished, regardless of any post-processor workflow (that removes the default `done` file).
- feat: creates the extractor failed signal, to correctly exit when the extractor has failed.