### PR TITLE
SPLAT-871 - fix(plugin-log): the should test exists checking the error

### DIFF
--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -14,8 +14,8 @@ set -o nounset
 os_log_info "[executor] Starting..."
 
 os_log_info "[executor] Checking if credentials are present..."
-test ! -f "${SA_CA_PATH}" || os_log_info "[executor] secret not found=${SA_CA_PATH}"
-test ! -f "${SA_TOKEN_PATH}" || os_log_info "[executor] secret not found=${SA_TOKEN_PATH}"
+test -f "${SA_CA_PATH}" || os_log_info "[executor] secret not found=${SA_CA_PATH}"
+test -f "${SA_TOKEN_PATH}" || os_log_info "[executor] secret not found=${SA_TOKEN_PATH}"
 
 #
 # Executor options


### PR DESCRIPTION
The files exist but the log is reporting as not due to the wrong test evaluation
```
#./executor.sh:17>  [executor] secret not found=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
#./executor.sh:18>  [executor] secret not found=/var/run/secrets/kubernetes.io/serviceaccount/token
```