### PR TITLE
SPLAT-869 - chore/manifests: rename plugins to be ordered by execution

### DIFF
--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -62,7 +62,7 @@ if [[ -n "${CERT_TEST_SUITE}" ]]; then
     os_log_info "openshift-tests finished[$?]"
     set +x
 
-# To run custom tests, set the environment CERT_LEVEL on plugin definition.
+# To run custom tests, set the environment PLUGIN_ID on plugin definition.
 # To generate the test file, use the script hack/generate-tests-tiers.sh
 elif [[ -n "${CERT_TEST_FILE:-}" ]]; then
     os_log_info "Running openshift-tests for custom tests [${CERT_TEST_FILE}]..."
@@ -87,7 +87,7 @@ elif [[ -n "${CUSTOM_TEST_FILTER_STR:-}" ]]; then
         | tee -a "${RESULTS_PIPE}" || true
 
 # Default execution - running default suite.
-# Set E2E_SUITE on plugin manifest to change it (unset CERT_LEVEL).
+# Set E2E_SUITE on plugin manifest to change it (unset PLUGIN_ID).
 else
     suite="${E2E_SUITE:-kubernetes/conformance}"
     os_log_info "Running default execution for openshift-tests suite [${suite}]..."

--- a/openshift-tests-provider-cert/plugin/global_env.sh
+++ b/openshift-tests-provider-cert/plugin/global_env.sh
@@ -6,7 +6,7 @@ declare -gx DEV_TESTS_COUNT
 
 declare -grx CERT_TESTS_DIR="./tests/${OPENSHIFT_VERSION:-"v4.10"}"
 
-declare -gx CERT_LEVEL
+declare -gx PLUGIN_ID
 declare -gx CERT_TEST_FILE
 declare -gx CERT_TEST_COUNT
 declare -gx CERT_TEST_SUITE
@@ -34,6 +34,9 @@ declare -grx SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 declare -grx UTIL_OTESTS_BIN="${SHARED_DIR}/openshift-tests"
 declare -grx UTIL_OTESTS_READY="${SHARED_DIR}/openshift-tests.ready"
 declare -grx UTIL_OTESTS_FAILED="${SHARED_DIR}/openshift-tests.failed"
+
+declare -grx PLUGIN_ID_KUBERNETES_CONFORMANCE="10"
+declare -grx PLUGIN_ID_OPENSHIFT_CONFORMANCE="20"
 
 # Defaults
 CERT_TEST_FILE=""

--- a/openshift-tests-provider-cert/plugin/global_fn.sh
+++ b/openshift-tests-provider-cert/plugin/global_fn.sh
@@ -34,37 +34,28 @@ create_dependencies_plugin() {
 # and PLUGIN_BLOCKED_BY.
 init_config() {
     os_log_info_local "[init_config]"
-    if [[ -z "${CERT_LEVEL:-}" ]]
+    if [[ -z "${PLUGIN_ID:-}" ]]
     then
-        os_log_info_local "Empty CERT_LEVEL. It should be defined. Exiting..."
+        os_log_info_local "Empty PLUGIN_ID. It should be defined. Exiting..."
         exit 1
     fi
 
-    os_log_info_local "Setting config for CERT_LEVEL=[${CERT_LEVEL:-}]..."
-    if [[ "${CERT_LEVEL:-}" == "0" ]]
+    os_log_info_local "Setting config for PLUGIN_ID=[${PLUGIN_ID:-}]..."
+
+    if [[ "${PLUGIN_ID:-}" == "${PLUGIN_ID_KUBERNETES_CONFORMANCE}" ]]
     then
-        PLUGIN_NAME="openshift-kube-conformance"
+        PLUGIN_NAME="10-openshift-kube-conformance"
         CERT_TEST_SUITE="kubernetes/conformance"
         PLUGIN_BLOCKED_BY=()
 
-    elif [[ "${CERT_LEVEL:-}" == "1" ]]
+    elif [[ "${PLUGIN_ID:-}" == "${PLUGIN_ID_OPENSHIFT_CONFORMANCE}" ]]
     then
-        PLUGIN_NAME="openshift-conformance-validated"
+        PLUGIN_NAME="20-openshift-conformance-validated"
         CERT_TEST_SUITE="openshift/conformance"
-        PLUGIN_BLOCKED_BY+=("openshift-kube-conformance")
-
-    elif [[ "${CERT_LEVEL:-}" == "2" ]]
-    then
-        PLUGIN_NAME="openshift-provider-cert-level2"
-        PLUGIN_BLOCKED_BY+=("openshift-conformance-validated")
-
-    elif [[ "${CERT_LEVEL:-}" == "3" ]]
-    then
-        PLUGIN_NAME="openshift-provider-cert-level3"
-        PLUGIN_BLOCKED_BY+=("openshift-provider-cert-level2")
+        PLUGIN_BLOCKED_BY+=("10-openshift-kube-conformance")
 
     else
-        os_log_info "[init_config] Unknow value for CERT_LEVEL=[${CERT_LEVEL:-}]"
+        os_log_info "[init_config] Unknow value for PLUGIN_ID=[${PLUGIN_ID:-}]"
         exit 1
     fi
 
@@ -82,7 +73,7 @@ show_config() {
 #> Config Dump [start] <#
 PLUGIN_NAME=${PLUGIN_NAME}
 PLUGIN_BLOCKED_BY=${PLUGIN_BLOCKED_BY[*]}
-CERT_LEVEL=${CERT_LEVEL}
+PLUGIN_ID=${PLUGIN_ID}
 CERT_TEST_SUITE=${CERT_TEST_SUITE}
 CERT_TEST_COUNT=${CERT_TEST_COUNT}
 CERT_TEST_PARALLEL=${CERT_TEST_PARALLEL}

--- a/openshift-tests-provider-cert/plugin/wait-plugin.sh
+++ b/openshift-tests-provider-cert/plugin/wait-plugin.sh
@@ -9,12 +9,12 @@ os_log_info_local() {
     os_log_info "$(date +%Y%m%d-%H%M%S)> [waiter] $*"
 }
 
-os_log_info_local "Starting Level[${CERT_LEVEL:-}]..."
+os_log_info_local "Starting Level[${PLUGIN_ID:-}]..."
 init_config
 
-os_log_info_local "Checking if there's plugins blocking Level${CERT_LEVEL:-} execution..."
+os_log_info_local "Checking if there's plugins blocking Level${PLUGIN_ID:-} execution..."
 if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
-    os_log_info_local "Level${CERT_LEVEL:-} plugin is blocked by: [${PLUGIN_BLOCKED_BY[*]}]"
+    os_log_info_local "Level${PLUGIN_ID:-} plugin is blocked by: [${PLUGIN_BLOCKED_BY[*]}]"
     for pod_label in "${PLUGIN_BLOCKED_BY[@]}"; do
         os_log_info_local "Waiting for pod running with label: ${pod_label}"
         kubectl wait \
@@ -24,7 +24,7 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
             -l sonobuoy-plugin="${pod_label}"
     done
 
-    os_log_info_local "Resource(s) ready! Waiting for Level[${CERT_LEVEL:-}]'s plugins be completed..."
+    os_log_info_local "Resource(s) ready! Waiting for Level[${PLUGIN_ID:-}]'s plugins be completed..."
     for bl_plugin_name in "${PLUGIN_BLOCKED_BY[@]}"; do
         os_log_info_local "Waiting 'completed' condition for pod: ${bl_plugin_name}"
         
@@ -87,4 +87,4 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
     os_log_info_local "All the conditions has been met!"
 fi
 
-os_log_info_local "Done for Level[${CERT_LEVEL:-}]."
+os_log_info_local "Done for Level[${PLUGIN_ID:-}]."


### PR DESCRIPTION
Rename the plugin to reflect the order of execution.

https://issues.redhat.com/browse/SPLAT-869

Relates to: 
- https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/30
- https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/31