### PR TITLE
SPLAT-870 - bump/tools: update tools image to sync for security and sync with CLI

### DIFF
--- a/openshift-tests-provider-cert/hack/build-image.sh
+++ b/openshift-tests-provider-cert/hack/build-image.sh
@@ -23,15 +23,15 @@ VERSION_PLUGIN_DEVEL="${VERSION_DEVEL:-}";
 FORCE="${FORCE:-false}";
 
 # TOOLS version is created by suffix of oc and sonobuoy versions w/o dots
-export VERSION_TOOLS="v0.0.0-oc41018-s0565"
-export VERSION_SONOBUOY="v0.56.5"
-export VERSION_OC="4.10.18"
+export VERSION_TOOLS="v0.0.0-alp3156-oc41113-s05610"
+export VERSION_SONOBUOY="v0.56.10"
+export VERSION_OC="4.11.13"
 
 IMAGE_PLUGIN="${REGISTRY_PLUGIN}/openshift-tests-provider-cert"
 IMAGE_TOOLS="${REGISTRY_TOOLS}/tools"
 IMAGE_SONOBUOY="docker.io/sonobuoy/sonobuoy"
 
-export CONTAINER_BASE="alpine:3.14"
+export CONTAINER_BASE="alpine:3.15.6"
 export CONTAINER_SONOBUOY="${IMAGE_SONOBUOY}:${VERSION_SONOBUOY}"
 export CONTAINER_SONOBUOY_MIRROR="${REGISTRY_MIRROR}/sonobuoy:${VERSION_SONOBUOY}"
 export CONTAINER_TOOLS="${IMAGE_TOOLS}:${VERSION_TOOLS}"


### PR DESCRIPTION
https://issues.redhat.com/browse/SPLAT-870

Update the Tools image for those reasons:
- update OC client to 4.11
- sync sonobuoy version with CLI: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/go.mod#L13
- security updates from Alpine
![Screenshot from 2022-11-09 14-01-03](https://user-images.githubusercontent.com/3216894/200893653-339317c4-9c83-414b-b825-264d114410c6.png)
