### PR TITLE
fix/splat-909: extracting oc from tests image - fix regressions

### DIFF
--- a/openshift-tests-provider-cert/hack/Containerfile.alp
+++ b/openshift-tests-provider-cert/hack/Containerfile.alp
@@ -7,7 +7,8 @@
 FROM ${CONTAINER_TOOLS}
 LABEL io.k8s.display-name="OpenShift Tests for Provider Certification Plugin" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
-      io.openshift.tags="openshift,tests,e2e,partner,certification,plugin"
+      io.openshift.tags="openshift,tests,e2e,partner,certification,plugin" \
+      io.openshift.opct.versions="base=${CONTAINER_BASE},sonobuoy=${VERSION_SONOBUOY},oc=${VERSION_OC}"
 WORKDIR /plugin
 
 COPY ./tests ./tests

--- a/openshift-tests-provider-cert/hack/build-image.sh
+++ b/openshift-tests-provider-cert/hack/build-image.sh
@@ -23,15 +23,15 @@ VERSION_PLUGIN_DEVEL="${VERSION_DEVEL:-}";
 FORCE="${FORCE:-false}";
 
 # TOOLS version is created by suffix of oc and sonobuoy versions w/o dots
-export VERSION_TOOLS="v0.0.0-alp3156-oc41113-s05610"
-export VERSION_SONOBUOY="v0.56.10"
-export VERSION_OC="4.11.13"
+export VERSION_TOOLS="v0.0.0-alp3163-oc41118-s05612"
+export VERSION_SONOBUOY="v0.56.12"
+export VERSION_OC="4.11.18"
 
 IMAGE_PLUGIN="${REGISTRY_PLUGIN}/openshift-tests-provider-cert"
 IMAGE_TOOLS="${REGISTRY_TOOLS}/tools"
 IMAGE_SONOBUOY="docker.io/sonobuoy/sonobuoy"
 
-export CONTAINER_BASE="alpine:3.15.6"
+export CONTAINER_BASE="alpine:3.16.3"
 export CONTAINER_SONOBUOY="${IMAGE_SONOBUOY}:${VERSION_SONOBUOY}"
 export CONTAINER_SONOBUOY_MIRROR="${REGISTRY_MIRROR}/sonobuoy:${VERSION_SONOBUOY}"
 export CONTAINER_TOOLS="${IMAGE_TOOLS}:${VERSION_TOOLS}"

--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -67,7 +67,7 @@ elif [[ "${PLUGIN_ID}" == "${PLUGIN_ID_OPENSHIFT_ARTIFACTS_COLLECTOR}" ]]; then
 
     pushd "${RESULTS_DIR}" || true
 
-    oc adm must-gather
+    ${UTIL_OC_BIN} adm must-gather
     tar cfJ artifacts_must-gather.tar.xz must-gather.local.*
 
     ${UTIL_OTESTS_BIN} run kubernetes/conformance --dry-run > ./artifacts_e2e-tests_kubernetes-conformance.txt

--- a/openshift-tests-provider-cert/plugin/global_env.sh
+++ b/openshift-tests-provider-cert/plugin/global_env.sh
@@ -31,10 +31,16 @@ declare -grx KUBE_API_INT="https://172.30.0.1:443"
 declare -grx SA_CA_PATH="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 declare -grx SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 
+# Utilities
 declare -grx UTIL_OTESTS_BIN="${SHARED_DIR}/openshift-tests"
-declare -grx UTIL_OTESTS_READY="${SHARED_DIR}/openshift-tests.ready"
-declare -grx UTIL_OTESTS_FAILED="${SHARED_DIR}/openshift-tests.failed"
+declare -grx UTIL_OTESTS_READY="${UTIL_OTESTS_BIN}.ready"
+declare -grx UTIL_OTESTS_FAILED="${UTIL_OTESTS_BIN}.failed"
 
+declare -grx UTIL_OC_BIN="/usr/bin/oc"
+declare -grx UTIL_OC_READY="${SHARED_DIR}/oc.ready"
+declare -grx UTIL_OC_FAILED="${SHARED_DIR}/oc.failed"
+
+# Plugins
 declare -grx PLUGIN_ID_KUBERNETES_CONFORMANCE="10"
 declare -grx PLUGIN_ID_OPENSHIFT_CONFORMANCE="20"
 declare -grx PLUGIN_ID_OPENSHIFT_ARTIFACTS_COLLECTOR="99"


### PR DESCRIPTION
This PR is a result of a regression investigation described on SPLAT-909 when validating the release v0.2.0 compared with the results of v0.1.0. The failures ratio increased from less than 1% to ~2.5% on OpenShift Conformance results running in cluster 4.10.z, which is not desired as the certification environment should not impact the test results

The root cause is on [this PR](https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/22) we bump the versions from the base image, which includes the update of oc (OpenShift CLI) from 4.10.18 to 4.11.13 used by `openshift-tests` utility.

That upgrade, ideally, should not impact. But we understood that the `openshift-tests` utility is validated, tested, and shipped in the payload, including the CLI for the same Y-stream, so we would not like to change that compatibility or include variables to impact on the `openshift-tests` runtime.

This PR updates the `oc` on the base image but will be replaced for the CLI included on the `tests` image extracted on the runtime, making sure the `openshift-tests` and `oc` are extracted from the same build.

We managed to decrease the failed ratio to less than 1% again on 4.10 clusters, similar v0.1.0. I also tested on 4.11.18 and 4.12.0-rc.4 achieving the expected results when compared with the first release.

Once this PR is merged, we will create the patch v0.2.1 and make this default for v0.2.

https://issues.redhat.com/browse/SPLAT-909