### PR TITLE
OPCT-15 - fix/waiter: increase plugin blocker timeout

### DIFF
--- a/openshift-tests-provider-cert/plugin/global_env.sh
+++ b/openshift-tests-provider-cert/plugin/global_env.sh
@@ -45,6 +45,11 @@ declare -grx PLUGIN_ID_KUBERNETES_CONFORMANCE="10"
 declare -grx PLUGIN_ID_OPENSHIFT_CONFORMANCE="20"
 declare -grx PLUGIN_ID_OPENSHIFT_ARTIFACTS_COLLECTOR="99"
 
+## Setting 3h for the plugin blocker feature (wait-plugin).
+## We don't want to run forever, however starting prematurely is not acceptable.
+declare -grx PLUGIN_WAIT_TIMEOUT_COUNT=1080
+declare -grx PLUGIN_WAIT_TIMEOUT_INTERVAL=10
+
 # Defaults
 CERT_TEST_FILE=""
 CERT_TEST_SUITE=""


### PR DESCRIPTION
Changes related to card OPCT-15.

This change increases the timeout of the blocker plugin to prevent the plugins start early when the blocker is taking longer (for example upgrade plugin used to take more than the current default).

Another plugin that can't start early is the artifacts collector, it could happen when the OCP conformance tests got stuck.

This change was initially implemented and tested on upgrade feature #24.