### PR TITLE
OPCT-23 - fix/waiter: unblock waiter when previous job failed

### DIFF
--- a/openshift-tests-provider-cert/plugin/global_env.sh
+++ b/openshift-tests-provider-cert/plugin/global_env.sh
@@ -50,6 +50,10 @@ declare -grx PLUGIN_ID_OPENSHIFT_ARTIFACTS_COLLECTOR="99"
 declare -grx PLUGIN_WAIT_TIMEOUT_COUNT=1080
 declare -grx PLUGIN_WAIT_TIMEOUT_INTERVAL=10
 
+# Sonobuot Plugin Statuses
+declare -grx SONOBUOY_PLUGIN_STATUS_COMPLETE="complete"
+declare -grx SONOBUOY_PLUGIN_STATUS_FAILED="failed"
+
 # Defaults
 CERT_TEST_FILE=""
 CERT_TEST_SUITE=""

--- a/openshift-tests-provider-cert/plugin/report-progress.sh
+++ b/openshift-tests-provider-cert/plugin/report-progress.sh
@@ -95,7 +95,7 @@ watch_dependency_done() {
             fi
 
             plugin_status=$(jq -r ".plugins[] | select (.plugin == \"${plugin_name}\" ) |.status // \"\"" "${STATUS_FILE}")
-            if [[ "${plugin_status}" == "complete" ]]; then
+            if [[ "${plugin_status}" == "${SONOBUOY_PLUGIN_STATUS_COMPLETE}" ]] || [[ "${plugin_status}" == "${SONOBUOY_PLUGIN_STATUS_FAILED}" ]]; then
                 echo "Plugin[${plugin_name}] with status[${plugin_status}] is finished!"
                 break
             fi

--- a/openshift-tests-provider-cert/plugin/wait-plugin.sh
+++ b/openshift-tests-provider-cert/plugin/wait-plugin.sh
@@ -44,7 +44,7 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
 
             os_log_info_local "Plugin[${bl_plugin_name}] with status[${plugin_status}]..."
             os_log_info_local "$(cat "${STATUS_FILE}")"
-            if [[ "${plugin_status}" == "complete" ]]; then
+            if [[ "${plugin_status}" == "${SONOBUOY_PLUGIN_STATUS_COMPLETE}" ]] || [[ "${plugin_status}" == "${SONOBUOY_PLUGIN_STATUS_FAILED}" ]]; then
                 os_log_info_local "Plugin[${bl_plugin_name}] with status[${plugin_status}] is completed!"
                 break
             fi


### PR DESCRIPTION
This PR prevents the blocker plugin to wait longer (until timeout) to run when the blocker plugin has been failed.

https://issues.redhat.com/browse/OPCT-23