### PR TITLE
opct9: standarize the name of artifact e2e-list

### DIFF
--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -88,7 +88,7 @@ elif [[ "${PLUGIN_ID}" == "${PLUGIN_ID_OPENSHIFT_ARTIFACTS_COLLECTOR}" ]]; then
     tar cfJ artifacts_must-gather.tar.xz must-gather.local.*
 
     ${UTIL_OTESTS_BIN} run kubernetes/conformance --dry-run > ./artifacts_e2e-tests_kubernetes-conformance.txt
-    ${UTIL_OTESTS_BIN} run openshift/conformance --dry-run > ./artifacts_e2e-openshift-conformance.txt
+    ${UTIL_OTESTS_BIN} run openshift/conformance --dry-run > ./artifacts_e2e-tests_openshift-conformance.txt
 
     tar cfz raw-results.tar.gz ./artifacts_*
 


### PR DESCRIPTION
We are standardizing the name of the artifact file used to collect the e2e tests used on the environment.

The artifacts will be extracted and a custom command to load this file is being developed on CLI[1], so this standard could help the development.

[1] https://issues.redhat.com/browse/OPCT-9