### PR TITLE
OPCT-9: Refact executor to run chunks by plugin

### DIFF
--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -159,8 +159,8 @@ collect_tests_upgrade() {
     ofile="./artifacts_e2e-tests_openshift-upgrade.txt"
     truncate -s 0 ${ofile}
     if [[ "${RUN_MODE:-''}" == "${PLUGIN_RUN_MODE_UPGRADE}" ]]; then
-        ${UTIL_OTESTS_BIN} run-upgrade "${suite}" --to-image "${UPGRADE_RELEASES}" --dry-run > ${ofile}
-        CNT_T=$(${UTIL_OTESTS_BIN} run-upgrade "${suite}" --to-image "${UPGRADE_RELEASES}" --dry-run | wc -l)
+        ${UTIL_OTESTS_BIN} run-upgrade "${suite}" --to-image "${UPGRADE_RELEASES:-}" --dry-run || true > ${ofile}
+        CNT_T=$(${UTIL_OTESTS_BIN} run-upgrade "${suite}" --to-image "${UPGRADE_RELEASES:-}" --dry-run || true | wc -l)
         os_log_info "[executor][PluginID#${PLUGIN_ID}] e2e count ${suite} openshift-tests> ${CNT_T}"
     fi
     CNT_C=$(wc -l ${ofile} | awk '{print$1}')

--- a/openshift-tests-provider-cert/plugin/report-progress.sh
+++ b/openshift-tests-provider-cert/plugin/report-progress.sh
@@ -237,6 +237,7 @@ report_progress() {
                 has_update=1;
             fi
             COUNTER_COMPLETED=$(( COUNTER_PASSED + COUNTER_SKIPPED + COUNTER_FAILED ))
+            PROGRESS["completed"]=${COUNTER_COMPLETED}
 
             # The COUNTER_TOTAL knows e2e tests defined on the suite (not including monitoring
             # tests).
@@ -246,7 +247,6 @@ report_progress() {
             fi
 
             if [[ $has_update -eq 1 ]] && [[ "${PLUGIN_ID}" != "${PLUGIN_ID_OPENSHIFT_UPGRADE}" ]]; then
-                PROGRESS["completed"]=${COUNTER_COMPLETED}
                 msg_st="T/C/P/F/S=${PROGRESS["total"]}/${COUNTER_COMPLETED}/${COUNTER_PASSED}/${COUNTER_FAILED}/${COUNTER_SKIPPED}"
                 update_progress "updater" "status=running=${msg_st}";
                 has_update=0;


### PR DESCRIPTION
Refact to:
- split the executor into chunks, and remove old fragments not valid for the current plugin (custom file, custom E2E, etc)
- standardized the files collected by the collector plugin, and processed by CLI[1]

[1] https://issues.redhat.com/browse/OPCT-9

Blocked by
- [x] #34 