### PR TITLE
OPCT-179: Bump base image to fix CVE; Update OC

### DIFF
--- a/openshift-tests-provider-cert/hack/build-image.sh
+++ b/openshift-tests-provider-cert/hack/build-image.sh
@@ -23,15 +23,15 @@ VERSION_PLUGIN_DEVEL="${VERSION_DEVEL:-}";
 FORCE="${FORCE:-false}";
 
 # TOOLS version is created by suffix of oc and sonobuoy versions w/o dots
-export VERSION_TOOLS="v0.0.0-alp3163-oc41118-s05612"
+export VERSION_TOOLS="v0.0.0-alp3164-oc4121-s05612"
 export VERSION_SONOBUOY="v0.56.12"
-export VERSION_OC="4.11.18"
+export VERSION_OC="4.12.1"
 
 IMAGE_PLUGIN="${REGISTRY_PLUGIN}/openshift-tests-provider-cert"
 IMAGE_TOOLS="${REGISTRY_TOOLS}/tools"
 IMAGE_SONOBUOY="docker.io/sonobuoy/sonobuoy"
 
-export CONTAINER_BASE="alpine:3.16.3"
+export CONTAINER_BASE="alpine:3.16.4"
 export CONTAINER_SONOBUOY="${IMAGE_SONOBUOY}:${VERSION_SONOBUOY}"
 export CONTAINER_SONOBUOY_MIRROR="${REGISTRY_MIRROR}/sonobuoy:${VERSION_SONOBUOY}"
 export CONTAINER_TOOLS="${IMAGE_TOOLS}:${VERSION_TOOLS}"


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-179

Changes:

1) Fixing the CVE-2022-43551 impacting `libcurl `and `curl` on the base image: https://quay.io/repository/ocp-cert/openshift-tests-provider-cert/manifest/sha256:7da47f5b75fce38b70f5cf09cc2fbe39264abbdeb111af7f31d2ae6f0b2fb183?tab=vulnerabilities
2) bump the OC cli to the current GA (4.12)

Steps to publish:

1) make the changes on the base image

2) build and push it (there is no pipeline for the plugin image)
```
$ bash hack/build-image.sh build-tools
$ bash hack/build-image.sh push-tools
```

3) Build the plugin image
- Review if the plugin image can be build with new base image
```
$ make build-dev
```

- Test the plugin image