### PR TITLE
OPCT-192: Automatically create changelog based on the tags

### DIFF
--- a/.github/workflows/changelog-configuration.json
+++ b/.github/workflows/changelog-configuration.json
@@ -1,0 +1,73 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": ["feature", "kind/feature"]
+    },
+    {
+      "title": "## 🛰 Design / API Change",
+      "labels": ["design", "kind/design", "kind/api-change"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix", "kind/bug"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["test", "kind/flake", "kind/failing-test"]
+    },
+    {
+      "title": "## ⛏ Cleanup",
+      "labels": ["cleanup", "kind/cleanup"]
+    },
+    {
+        "title": "## 📦 Dependencies",
+        "labels": ["dependencies", "kind/dependency-change"]
+    },
+    {
+        "title": "## 📜 Documentation",
+        "labels": ["docs", "documentation", "kind/documentation"]
+    },
+    {
+      "title": "## 💬 Other",
+      "labels": ["other"]
+    }
+  ],
+  "ignore_labels": [
+    "ignore"
+  ],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  },
+  "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
+  "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+  "empty_template": "- no changes",
+  "label_extractor": [
+    {
+      "pattern": "(.) (.+)",
+      "target": "$1",
+      "flags": "gu"
+    },
+    {
+      "pattern": "\\[Issue\\]",
+      "on_property": "title",
+      "method": "match"
+    }
+  ],
+  "duplicate_filter": {
+    "pattern": "\\[ABC-....\\]",
+    "on_property": "title",
+    "method": "match"
+  },
+  "transformers": [
+    {
+      "pattern": "[\\-\\*] (\\[(...|TEST|CI|SKIP)\\])( )?(.+?)\n(.+?[\\-\\*] )(.+)",
+      "target": "- $4\n  - $6"
+    }
+  ],
+  "trim_values": false,
+  "max_tags_to_fetch": 200,
+  "max_pull_requests": 200,
+  "max_back_track_time_days": 365
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,25 +28,29 @@ jobs:
           scandir: './openshift-tests-provider-cert/hack/*.sh'
 
 #
-# Tests related to plugin: openshift-tests
+# TODO: Tests related to plugin: openshift-tests
 #
-  plugin-openshift-tests-e2e:
-    runs-on: ubuntu-latest
-    needs:
-      - linters
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+  # plugin-openshift-tests-e2e:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - linters
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
 
-      - name: e2e
-        run: |
-          echo "e2e Not implemented."
+  #     - name: e2e
+  #       run: |
+  #         echo "e2e Not implemented."
 
+#
+# Build container image
+# TODO: push to external registry when lifecycle is created
+#
   plugin-openshift-tests-build:
     runs-on: ubuntu-latest
     needs:
       - linters
-      - plugin-openshift-tests-e2e
+     # - plugin-openshift-tests-e2e
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +61,7 @@ jobs:
           make build-ci
 
 #
-# Releasing
+# Releasing: triggered when a tag is created
 #
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -81,3 +85,21 @@ jobs:
           podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io
           cd openshift-tests-provider-cert/;
           make release VERSION=$RELEASE_VERSION
+
+      # https://github.com/mikepenz/release-changelog-builder-action#configuration
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v3.7.0
+        with:
+          configuration: ".github/workflows/changelog-configuration.json"
+
+      # https://github.com/softprops/action-gh-release
+      - name: Create Release on Github
+        uses: softprops/action-gh-release@v0.1.15
+        env:
+          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+        with:
+          body: |
+            ## Changelog
+            Image published to [quay.io/ocp-cert/openshift-tests-provider-cert:$RELEASE_VERSION](https://quay.io/repository/ocp-cert/openshift-tests-provider-cert?tab=tags)
+            ${{steps.github_release.outputs.changelog}}


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-192

This PR introduces the action plugin to generate the changelog for each release.