### PR TITLE
OPCT-12: Embed on tools image the etcd log parser

### DIFF
--- a/openshift-tests-provider-cert/.gitignore
+++ b/openshift-tests-provider-cert/.gitignore
@@ -2,3 +2,4 @@
 VERSION
 Containerfile
 Containerfile.tools
+build/

--- a/openshift-tests-provider-cert/Makefile
+++ b/openshift-tests-provider-cert/Makefile
@@ -13,6 +13,12 @@ build-dev:
 	VERSION_DEVEL=devel REGISTRY_PLUGIN=$(DEV_REGISTRY) hack/build-image.sh build-dev
 .PHONY: build-dev
 
+build-tool-etcd-log-filter:
+	mkdir -p build/
+	go build -o build/ocp-etcd-log-filters \
+		-ldflags="-s -w" cmd/ocp-etcd-log-filters/*.go
+.PHONY: build-tool-etcd-log-filter
+
 release:
 	VERSION_PLUGIN=$(VERSION) hack/build-image.sh release
 .PHONY: release

--- a/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/applyTookLong.go
+++ b/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/applyTookLong.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+)
+
+// LogPayloadETCD parses the etcd log file to extract insights
+// {"level":"warn","ts":"2023-03-01T15:14:22.192Z",
+// "caller":"etcdserver/util.go:166",
+// "msg":"apply request took too long",
+// "took":"231.023586ms","expected-duration":"200ms",
+// "prefix":"read-only range ",
+// "request":"key:\"/kubernetes.io/configmaps/kube-system/kube-controller-manager\" ",
+// "response":"range_response_count:1 size:608"}
+type LogPayloadETCD struct {
+	Took      string `json:"took"`
+	Timestamp string `json:"ts"`
+}
+
+type BucketGroup struct {
+	Bukets1s    Buckets
+	Bukets500ms Buckets
+}
+
+type FilterApplyTookTooLong struct {
+	Name    string
+	GroupBy string
+	Group   map[string]*BucketGroup
+
+	// filter config
+	lineFilter     string
+	reLineSplitter *regexp.Regexp
+	reMili         *regexp.Regexp
+	reSec          *regexp.Regexp
+	reTsMin        *regexp.Regexp
+	reTsHour       *regexp.Regexp
+	reTsDay        *regexp.Regexp
+}
+
+func NewFilterApplyTookTooLong(aggregator string) *FilterApplyTookTooLong {
+	var filter FilterApplyTookTooLong
+
+	filter.Name = "ApplyTookTooLong"
+	filter.GroupBy = aggregator
+	filter.Group = make(map[string]*BucketGroup)
+
+	filter.lineFilter = "apply request took too long"
+	filter.reLineSplitter, _ = regexp.Compile(`^\d+-\d+-\d+T\d+:\d+:\d+.\d+Z `)
+	filter.reMili, _ = regexp.Compile("([0-9]+.[0-9]+)ms")
+	filter.reSec, _ = regexp.Compile("([0-9]+.[0-9]+)s")
+	filter.reTsMin, _ = regexp.Compile(`^(\d+-\d+-\d+T\d+:\d+):\d+.\d+Z`)
+	filter.reTsHour, _ = regexp.Compile(`^(\d+-\d+-\d+T\d+):\d+:\d+.\d+Z`)
+	filter.reTsDay, _ = regexp.Compile(`^(\d+-\d+-\d+)T\d+:\d+:\d+.\d+Z`)
+
+	return &filter
+}
+
+func (f *FilterApplyTookTooLong) ProcessLine(line string) {
+
+	// filter by required filter
+	if !strings.Contains(line, f.lineFilter) {
+		return
+	}
+
+	// split timestamp
+	split := f.reLineSplitter.Split(line, -1)
+	if len(split) < 1 {
+		return
+	}
+
+	// parse json
+	lineParsed := LogPayloadETCD{}
+	json.Unmarshal([]byte(split[1]), &lineParsed)
+
+	if match := f.reMili.MatchString(lineParsed.Took); match { // Extract milisseconds
+		matches := f.reMili.FindStringSubmatch(lineParsed.Took)
+		if len(matches) == 2 {
+			if v, err := strconv.ParseFloat(matches[1], 64); err == nil {
+				f.insertBucket(v, lineParsed.Timestamp)
+			}
+		}
+	} else if match := f.reSec.MatchString(lineParsed.Took); match { // Extract seconds
+		matches := f.reSec.FindStringSubmatch(lineParsed.Took)
+		if len(matches) == 2 {
+			if v, err := strconv.ParseFloat(matches[1], 64); err == nil {
+				v = v * 1000
+				f.insertBucket(v, lineParsed.Timestamp)
+			}
+		}
+	} else {
+		fmt.Printf("No bucket for: %v\n", lineParsed.Took)
+	}
+}
+
+func (f *FilterApplyTookTooLong) insertBucket(v float64, ts string) {
+	var group *BucketGroup
+	var aggrKey string
+
+	if f.GroupBy == "hour" {
+		aggrValue := "all"
+		if match := f.reTsHour.MatchString(ts); match {
+			matches := f.reTsHour.FindStringSubmatch(ts)
+			aggrValue = matches[1]
+		}
+		aggrKey = aggrValue
+	} else if f.GroupBy == "day" {
+		aggrValue := "all"
+		if match := f.reTsDay.MatchString(ts); match {
+			matches := f.reTsDay.FindStringSubmatch(ts)
+			aggrValue = matches[1]
+		}
+		aggrKey = aggrValue
+	} else if f.GroupBy == "minute" || f.GroupBy == "min" {
+		aggrValue := "all"
+		if match := f.reTsMin.MatchString(ts); match {
+			matches := f.reTsMin.FindStringSubmatch(ts)
+			aggrValue = matches[1]
+		}
+		aggrKey = aggrValue
+	} else {
+		aggrKey = f.GroupBy
+	}
+
+	if _, ok := f.Group[aggrKey]; !ok {
+		f.Group[aggrKey] = &BucketGroup{}
+		group = f.Group[aggrKey]
+		group.Bukets1s = NewBuckets(buckets1s())
+		group.Bukets500ms = NewBuckets(buckets500ms())
+	} else {
+		group = f.Group[aggrKey]
+	}
+
+	b1s := group.Bukets1s
+	b500ms := group.Bukets500ms
+
+	switch {
+	case v < 200.0:
+		k := "low-200"
+		b1s[k] += 1
+		b500ms[k] += 1
+	case ((v >= 200.0) && (v <= 299.0)):
+		k := "200-300"
+		b1s[k] += 1
+		b500ms[k] += 1
+	case ((v >= 300.0) && (v <= 399.0)):
+		k := "300-400"
+		b1s[k] += 1
+		b500ms[k] += 1
+	case ((v >= 400.0) && (v <= 499.0)):
+		k := "400-500"
+		b1s[k] += 1
+		b500ms[k] += 1
+	case ((v >= 500.0) && (v <= 599.0)):
+		k := "500-600"
+		b1s[k] += 1
+		k = "500-inf"
+		b500ms[k] += 1
+	case ((v >= 600.0) && (v <= 699.0)):
+		k := "600-700"
+		b1s[k] += 1
+		k = "500-inf"
+		b500ms[k] += 1
+	case ((v >= 700.0) && (v <= 799.0)):
+		k := "700-800"
+		b1s[k] += 1
+		k = "500-inf"
+		b500ms[k] += 1
+	case ((v >= 800.0) && (v <= 899.0)):
+		k := "800-900"
+		b1s[k] += 1
+		k = "500-inf"
+		b500ms[k] += 1
+	case ((v >= 900.0) && (v <= 999.0)):
+		k := "900-1s"
+		b1s[k] += 1
+		k = "500-inf"
+		b500ms[k] += 1
+	case (v >= 1000.0):
+		k := "1s-inf"
+		b1s[k] += 1
+
+		k = "500-inf"
+		b500ms[k] += 1
+	default:
+		k := "unkw"
+		b1s[k] += 1
+		b500ms[k] += 1
+	}
+	k := "all"
+
+	b1s[k] += 1
+	b500ms[k] += 1
+}
+
+func (f *FilterApplyTookTooLong) Show() {
+
+	fmt.Printf("> Filter Name: %s\n", f.Name)
+
+	fmt.Printf("> Group by: %s\n", f.GroupBy)
+	for aggr, group := range f.Group {
+		if aggr != "all" {
+			fmt.Printf("\n>> %s\n", aggr)
+		}
+		b1s := group.Bukets1s
+		b500ms := group.Bukets500ms
+
+		tbWriter := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)
+		show := func(k string) {
+			v := b1s[k]
+			perc := fmt.Sprintf("(%.3f %%)", (float64(v)/float64(b1s["all"]))*100)
+			if k == "all" {
+				perc = ""
+			}
+			fmt.Fprintf(tbWriter, "%s\t %d\t%s\n", k, v, perc)
+		}
+
+		fmt.Println(">>> Summary <<<")
+		show("all")
+
+		v500 := b500ms["500-inf"]
+		perc500inf := (float64(v500) / float64(b500ms["all"])) * 100
+		fmt.Fprintf(tbWriter, ">500ms\t %d\t(%.3f %%)\n", v500, perc500inf)
+		fmt.Fprintf(tbWriter, "---\n")
+
+		fmt.Println(">>> Buckets <<<")
+		show("low-200")
+		show("200-300")
+		show("300-400")
+		show("400-500")
+		show("500-600")
+		show("600-700")
+		show("700-800")
+		show("800-900")
+		show("900-1s")
+		show("1s-inf")
+		show("unkw")
+
+		tbWriter.Flush()
+
+	}
+}

--- a/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/buckets.go
+++ b/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/buckets.go
@@ -1,0 +1,38 @@
+package main
+
+func buckets1s() []string {
+	return []string{
+		"low-200",
+		"200-300",
+		"300-400",
+		"400-500",
+		"500-600",
+		"600-700",
+		"700-800",
+		"800-900",
+		"900-1s",
+		"1s-inf",
+		"all",
+	}
+}
+
+func buckets500ms() []string {
+	return []string{
+		"low-200",
+		"200-300",
+		"300-400",
+		"400-500",
+		"500-inf",
+		"all",
+	}
+}
+
+type Buckets map[string]uint64
+
+func NewBuckets(values []string) Buckets {
+	buckets := make(map[string]uint64, len(values))
+	for _, v := range values {
+		buckets[v] = 0
+	}
+	return buckets
+}

--- a/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/main.go
+++ b/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/main.go
@@ -1,0 +1,27 @@
+// ocp-etcd-log-filters parses the logs of etcd from stdin
+//
+//	$ cat must-gather.local.*/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log \
+//	  | ./ocp-etcd-log-filters [options]
+package main
+
+import (
+	"bufio"
+	"flag"
+	"os"
+)
+
+func main() {
+
+	aggregator := flag.String("aggregator", "all", "Aggregator. Valid: all, day, hour, minute. Default: all")
+	flag.Parse()
+
+	filterATTL := NewFilterApplyTookTooLong(*aggregator)
+
+	s := bufio.NewScanner(os.Stdin)
+	for s.Scan() {
+		line := s.Text()
+		filterATTL.ProcessLine(line)
+	}
+
+	filterATTL.Show()
+}

--- a/openshift-tests-provider-cert/hack/Containerfile.tools-alp
+++ b/openshift-tests-provider-cert/hack/Containerfile.tools-alp
@@ -3,10 +3,14 @@
 # hack/Containerfile.alp
 # hack/Containerfile.tools-alp
 
-# Sonobuoy
+#
+## Sonobuoy
+#
 FROM ${CONTAINER_SONOBUOY_MIRROR} as sonobuoy
 
-# Base image
+#
+## Base image
+#
 FROM ${CONTAINER_BASE} as base
 
 # gcompat: allow to run glibc programs (oc and jq)
@@ -25,7 +29,20 @@ RUN apk add --no-cache --update tar binutils \
     && chmod +x jq oc \
     && strip oc
 
-# Tools image
+#
+## ocp-etcd-log-filters builder
+#
+FROM golang:1.19-alpine as oelf-builder
+
+COPY cmd/ocp-etcd-log-filters/*.go $GOPATH/src/github.com/opct/plugins/
+WORKDIR $GOPATH/src/github.com/opct/plugins/
+ADD cmd/ocp-etcd-log-filters/*.go .
+RUN go build -ldflags="-s -w" \
+    -o /usr/bin/ocp-etcd-log-filters *.go
+
+#
+## Tools image
+#
 FROM base
 LABEL io.k8s.display-name="OpenShift Tests for Provider Certification Tools" \
       io.k8s.description="OpenShift is a platform for developing, building, and deploying containerized applications." \
@@ -34,6 +51,7 @@ WORKDIR /tools
 COPY --from=sonobuoy /sonobuoy /usr/bin/
 COPY --from=clients /clients/oc /usr/bin/
 COPY --from=clients /clients/jq /usr/bin/
+COPY --from=oelf-builder /usr/bin/ocp-etcd-log-filters /usr/bin/
 RUN ln -svf /usr/bin/oc /usr/bin/kubectl
 
 RUN rm -rf /var/cache/apk/*

--- a/openshift-tests-provider-cert/hack/build-image.sh
+++ b/openshift-tests-provider-cert/hack/build-image.sh
@@ -23,15 +23,15 @@ VERSION_PLUGIN_DEVEL="${VERSION_DEVEL:-}";
 FORCE="${FORCE:-false}";
 
 # TOOLS version is created by suffix of oc and sonobuoy versions w/o dots
-export VERSION_TOOLS="v0.0.0-alp3164-oc4121-s05612"
-export VERSION_SONOBUOY="v0.56.12"
+export VERSION_TOOLS="v0.0.0-alp3164-oc4121-s05612-v0"
+export CONTAINER_BASE="alpine:3.16.4"
 export VERSION_OC="4.12.1"
+export VERSION_SONOBUOY="v0.56.12"
 
 IMAGE_PLUGIN="${REGISTRY_PLUGIN}/openshift-tests-provider-cert"
 IMAGE_TOOLS="${REGISTRY_TOOLS}/tools"
 IMAGE_SONOBUOY="docker.io/sonobuoy/sonobuoy"
 
-export CONTAINER_BASE="alpine:3.16.4"
 export CONTAINER_SONOBUOY="${IMAGE_SONOBUOY}:${VERSION_SONOBUOY}"
 export CONTAINER_SONOBUOY_MIRROR="${REGISTRY_MIRROR}/sonobuoy:${VERSION_SONOBUOY}"
 export CONTAINER_TOOLS="${IMAGE_TOOLS}:${VERSION_TOOLS}"

--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -137,7 +137,14 @@ collect_must_gather() {
     # TODO: Pre-process data from must-gather to avoid client-side extra steps.
     # Examples of data to be processed:
     # > insights rules
-    # > etcd latency parser from logs
+
+    # extracting msg from etcd logs: request latency apply took too long (attl)
+    cat must-gather-opct/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log \
+        | ocp-etcd-log-filters \
+        > artifacts_must-gather_parser-etcd-attl-all.txt
+    cat must-gather-opct/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log \
+        | ocp-etcd-log-filters -aggregator hour \
+        > artifacts_must-gather_parser-etcd-attl-hour.txt
 
     # Create the tarball file artifacts_must-gather.tar.xz
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Packing must-gather"


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-12

Embed the tool used on the review process to parse etcd logs from must-gather filtering by slowly apply requests. It will aggregate the slow requests into buckets of 100ms, sharing counters for each one and which bucket the slow requests stayed, useful when comparing executions with baseline HW (reference) and new ones on the time frame the e2e tests have.

For reference:

- expected to have fewer requests reporting higher than 500ms

```
$ cat ~/opct/tmp/must-gather/must-gather-opct/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log  \
 | ./build/ocp-etcd-log-filters 
> Filter Name: ApplyTookTooLong
> Group by: all
>>> Summary <<<
all	 16949	
>500ms	 1485	(8.762 %)
---
>>> Buckets <<<
low-200	 0	(0.000 %)
200-300	 9340	(55.106 %)
300-400	 4169	(24.597 %)
400-500	 1853	(10.933 %)
500-600	 716	(4.224 %)
600-700	 223	(1.316 %)
700-800	 185	(1.092 %)
800-900	 139	(0.820 %)
900-1s	 79	(0.466 %)
1s-inf	 143	(0.844 %)
unkw	 102	(0.602 %)

```

- aggregating by hour

```
$ cat ~/opct/tmp/must-gather/must-gather-opct/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log  \
 | ./build/ocp-etcd-log-filters -aggregator hour
> Filter Name: ApplyTookTooLong
> Group by: hour

>> 2023-03-01T17
>>> Summary <<<
all	 558	
>500ms	 54	(9.677 %)
---
>>> Buckets <<<
low-200	 0	(0.000 %)
200-300	 385	(68.996 %)
300-400	 90	(16.129 %)
400-500	 28	(5.018 %)
500-600	 9	(1.613 %)
600-700	 10	(1.792 %)
700-800	 7	(1.254 %)
800-900	 9	(1.613 %)
900-1s	 16	(2.867 %)
1s-inf	 3	(0.538 %)
unkw	 1	(0.179 %)

>> 2023-03-01T15
>>> Summary <<<
all	 7740	
>500ms	 619	(7.997 %)
---
>>> Buckets <<<
low-200	 0	(0.000 %)
200-300	 4122	(53.256 %)
300-400	 2107	(27.222 %)
400-500	 842	(10.879 %)
500-600	 379	(4.897 %)
600-700	 78	(1.008 %)
700-800	 67	(0.866 %)
800-900	 55	(0.711 %)
900-1s	 15	(0.194 %)
1s-inf	 25	(0.323 %)
unkw	 50	(0.646 %)

>> 2023-03-01T16
>>> Summary <<<
all	 8651	
>500ms	 812	(9.386 %)
---
>>> Buckets <<<
low-200	 0	(0.000 %)
200-300	 4833	(55.866 %)
300-400	 1972	(22.795 %)
400-500	 983	(11.363 %)
500-600	 328	(3.791 %)
600-700	 135	(1.561 %)
700-800	 111	(1.283 %)
800-900	 75	(0.867 %)
900-1s	 48	(0.555 %)
1s-inf	 115	(1.329 %)
unkw	 51	(0.590 %)

```