### PR TITLE
OPCT-209: update base image to fix security CVEs

### DIFF
--- a/openshift-tests-provider-cert/hack/build-image.sh
+++ b/openshift-tests-provider-cert/hack/build-image.sh
@@ -23,8 +23,8 @@ VERSION_PLUGIN_DEVEL="${VERSION_DEVEL:-}";
 FORCE="${FORCE:-false}";
 
 # TOOLS version is created by suffix of oc and sonobuoy versions w/o dots
-export VERSION_TOOLS="v0.0.0-alp3164-oc4121-s05612-v0"
-export CONTAINER_BASE="alpine:3.16.4"
+export VERSION_TOOLS="v0.0.0-alp3165-oc4121-s05612-v0"
+export CONTAINER_BASE="alpine:3.16.5"
 export VERSION_OC="4.12.1"
 export VERSION_SONOBUOY="v0.56.12"
 


### PR DESCRIPTION
Fixing CVEs from the base image.

[OPCT-209](https://issues.redhat.com/browse/OPCT-209)
[OPCT-177](https://issues.redhat.com/browse/OPCT-177)

![Screenshot from 2023-05-17 01-13-24](https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/assets/3216894/a70eea5c-b4f2-4edd-a2ba-96a27e22eb06)
