### PR TITLE
OPCT-210: added stats on etcd-parser-attl tool

### DIFF
--- a/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/buckets.go
+++ b/openshift-tests-provider-cert/cmd/ocp-etcd-log-filters/buckets.go
@@ -27,12 +27,12 @@ func buckets500ms() []string {
 	}
 }
 
-type Buckets map[string]uint64
+type Buckets map[string][]float64
 
 func NewBuckets(values []string) Buckets {
-	buckets := make(map[string]uint64, len(values))
+	buckets := make(Buckets, len(values))
 	for _, v := range values {
-		buckets[v] = 0
+		buckets[v] = []float64{}
 	}
 	return buckets
 }

--- a/openshift-tests-provider-cert/hack/Containerfile.tools-alp
+++ b/openshift-tests-provider-cert/hack/Containerfile.tools-alp
@@ -37,7 +37,7 @@ FROM golang:1.19-alpine as oelf-builder
 COPY cmd/ocp-etcd-log-filters/*.go $GOPATH/src/github.com/opct/plugins/
 WORKDIR $GOPATH/src/github.com/opct/plugins/
 ADD cmd/ocp-etcd-log-filters/*.go .
-RUN go build -ldflags="-s -w" \
+RUN go mod init && go mod tidy && go build -ldflags="-s -w" \
     -o /usr/bin/ocp-etcd-log-filters *.go
 
 #


### PR DESCRIPTION
Adding stats to the ETCD log requests taking too long parser:

- From

~~~
> Filter Name: ApplyTookTooLong
> Group by: all
>>> Summary <<<
all	 120	
>500ms	 34	(28.333 %)
---
>>> Buckets <<<
low-200	 0	(0.000 %)
200-300	 40	(33.333 %)
300-400	 25	(20.833 %)
400-500	 20	(16.667 %)
500-600	 19	(15.833 %)
600-700	 8	(6.667 %)
700-800	 4	(3.333 %)
800-900	 1	(0.833 %)
900-1s	 0	(0.000 %)
1s-inf	 2	(1.667 %)
unkw	 1	(0.833 %)

~~~

- To
~~~
= Filter Name: ApplyTookTooLong =
== Group by: all ==
=== Summary ===
     all    120            
  >500ms     34 (28.333 %)
---
=== Buckets (ms) ===
 200-300     40  (33.333 %) |  600-700      8   (6.667 %) |   1s-inf      2   (1.667 %)
 300-400     26  (21.667 %) |  700-800      4   (3.333 %) |     unkw      0   (0.000 %)
 400-500     20  (16.667 %) |  800-900      1   (0.833 %)
 500-600     19  (15.833 %) |   900-1s      0   (0.000 %)
unkw : []
=== Timers ===
 Count 		:               120	|     Median 	: 385.757 (ms)
   Min 		:      200.848 (ms)	|        P90 	: 608.940747 (ms)
   Max 		:     1379.912 (ms)	|        P99 	: 1077.006 (ms)
   Sum 		:    50405.496 (ms)	|      P99.9 	: 1355.251 (ms)
Average 	:      420.046 (ms)	|     StdDev 	: 192.323 (ms)
Outliers 	: {Mild:[] Extreme:[1330.5906089999999 1379.91236]}

~~~

## Usage

Outside OPCT:

~~~
$ cat ${MUST_GATHER_PATH}/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log | ~/bin/ocp-etcd-log-filters
~~~

Available in OPCT archive:

~~~
$ ls .plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather_parser-etcd-attl-*.txt 
plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather_parser-etcd-attl-all.txt
plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather_parser-etcd-attl-hour.txt
~~~