### PR TITLE
OPCT-226: Added camgi report to artifact collector plugin

### DIFF
--- a/openshift-tests-provider-cert/hack/Containerfile.tools-alp
+++ b/openshift-tests-provider-cert/hack/Containerfile.tools-alp
@@ -1,5 +1,5 @@
 # Code generated for package assets by build-image.sh. DO NOT EDIT.
-# sources:
+# Instead, edit the sources container files:
 # hack/Containerfile.alp
 # hack/Containerfile.tools-alp
 
@@ -23,11 +23,13 @@ WORKDIR /clients
 
 ADD https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/${VERSION_OC}/openshift-client-linux.tar.gz ./
 ADD https://github.com/jqlang/jq/releases/download/jq-1.4/jq-linux-x86_64 ./
+ADD https://github.com/elmiko/camgi.rs/releases/download/v0.9.0/camgi-0.9.0-linux-x86_64.tar ./
 RUN microdnf install -y binutils \
     && tar xvfz openshift-client-linux.tar.gz \
     && rm -f openshift-client-linux.tar.gz kubectl README.md \
-    && chmod +x jq-linux-x86_64 oc \
-    && strip oc
+    && tar xvf camgi-0.9.0-linux-x86_64.tar && rm camgi-0.9.0-linux-x86_64.tar \
+    && chmod +x jq-linux-x86_64 oc camgi \
+    && strip oc && strip camgi
 
 #
 ## ocp-etcd-log-filters builder
@@ -51,6 +53,7 @@ WORKDIR /tools
 COPY --from=sonobuoy /sonobuoy /usr/bin/
 COPY --from=clients /clients/oc /usr/bin/
 COPY --from=clients /clients/jq-linux-x86_64 /usr/bin/jq
+COPY --from=clients /clients/camgi /usr/bin/camgi
 COPY --from=oelf-builder /usr/bin/ocp-etcd-log-filters /usr/bin/
 RUN ln -svf /usr/bin/oc /usr/bin/kubectl
 

--- a/openshift-tests-provider-cert/hack/build-image.sh
+++ b/openshift-tests-provider-cert/hack/build-image.sh
@@ -26,7 +26,7 @@ FORCE="${FORCE:-false}";
 export CONTAINER_BASE_GOBUILD="golang:1.19-alpine"
 export CONTAINER_BASE_BUILD="alpine:3.16.5"
 export CONTAINER_BASE="quay.io/fedora/fedora-minimal:38-x86_64"
-export VERSION_TOOLS="v0.1.0"
+export VERSION_TOOLS="v0.2.0"
 export VERSION_OC="4.13.3"
 export VERSION_SONOBUOY="v0.56.12"
 
@@ -134,7 +134,7 @@ push_tools() {
     cmd_succeeded=$( image_exists "${IMAGE_TOOLS}" "${VERSION_TOOLS}"; echo $? )
     if [[ $cmd_succeeded -eq 0 ]] && [[ $FORCE == false ]]; then
         echo "#>> Tools container already exists. Ignoring push."
-        exit 1
+        return
     fi
     echo "#> Starting Tools container pusher"
     pusher_tools
@@ -180,7 +180,7 @@ build_plugin() {
     echo "#> Checking Tools container image"
     cmd_succeeded=$( image_exists "${IMAGE_TOOLS}" "${VERSION_TOOLS}"; echo $? )
     if [[ $cmd_succeeded -eq 1 ]] && [[ $FORCE == false ]]; then
-        echo "#>> Tools container already exists. Ignoring push."
+        echo "#>> Tools image [${IMAGE_TOOLS}:${VERSION_TOOLS}] does not exists. build it with options build-tools and push-tools."
         exit 1
     fi
     builder_plugin

--- a/openshift-tests-provider-cert/plugin/executor.sh
+++ b/openshift-tests-provider-cert/plugin/executor.sh
@@ -139,12 +139,17 @@ collect_must_gather() {
     # > insights rules
 
     # extracting msg from etcd logs: request latency apply took too long (attl)
+    os_log_info "[executor][PluginID#${PLUGIN_ID}] Collecting etcd log filters"
     cat must-gather-opct/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log \
         | ocp-etcd-log-filters \
         > artifacts_must-gather_parser-etcd-attl-all.txt
     cat must-gather-opct/*/namespaces/openshift-etcd/pods/*/etcd/etcd/logs/current.log \
         | ocp-etcd-log-filters -aggregator hour \
         > artifacts_must-gather_parser-etcd-attl-hour.txt
+
+    # generate camgi report
+    os_log_info "[executor][PluginID#${PLUGIN_ID}] Generating camgi report"
+    camgi must-gather-opct/ > artifacts_must-gather_camgi.html || true
 
     # Create the tarball file artifacts_must-gather.tar.xz
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Packing must-gather"


### PR DESCRIPTION
This change introduces the [camgi](https://github.com/elmiko/camgi.rs) report to the artifact collector plugin - results artifacts:

~~~
$ tree plugins/99-openshift-artifacts-collector/
plugins/99-openshift-artifacts-collector/
├── definition.json
├── results
│   └── global
(...)
│       ├── artifacts_must-gather_camgi.html
(...)
└── sonobuoy_results.yaml

~~~

CAMGI is a tool broadly used in OCP CI to help to troubleshoot many objects in must-gather with a friendly interface.

The binary is pretty small, increasing 700 MiB to the compressed image in the Quay.io, and ~1MiB local.

~~~
$ podman images |grep tools
quay.io/ocp-cert/tools                                   v0.1.0                              66dad94e6c9f  56 minutes ago  253 MB
quay.io/ocp-cert/tools                                   v0.0.0-f38min-oc4133-s05612-v0      58b81800eeca  4 weeks ago     252 MB
~~~

The report camgi.html could be bigger, depending on the size and logs in must-gather. The estimated size would be ~30-40MiB.

This image will also produce a human-friendly version (SemVer) for the tools image (base image), preventing adding features to the label.

This PR also can help in the report improvement introduced in https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/76 .

Status:

- [x] embed camgi binary to the base image
- [x] build a dev image and test it
- [x] Merge https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/43 (and rebase here)
- [x] change the tools image from this PR to v0.2.0 (leave v0.1.0 to #43)
- [ ] update OPCT documentation