### PR TITLE
OPCT-246: Introducing must-gather-monitoring to collect metrics

### DIFF
--- a/must-gather-monitoring/Containerfile
+++ b/must-gather-monitoring/Containerfile
@@ -1,0 +1,22 @@
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:cli
+
+FROM quay.io/openshift/origin-must-gather:4.14.0 as builder
+
+FROM quay.io/centos/centos:stream8
+
+# For gathering data from nodes
+RUN dnf update -y && \
+    dnf install util-linux rsync -y && \
+    dnf clean all
+
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+
+# Copy all collection scripts to /usr/bin
+COPY collection-scripts/* /usr/bin/
+
+# runner_plugin is used when the Must-gather is called as a sonobuoy plugin
+COPY runner_plugin /usr/bin/
+
+RUN chmod u+x /usr/bin/gather* /usr/bin/runner_plugin
+
+ENTRYPOINT /usr/bin/gather

--- a/must-gather-monitoring/Makefile
+++ b/must-gather-monitoring/Makefile
@@ -1,0 +1,14 @@
+
+CMD_CNT ?= podman
+IMAGE_NAME ?= quay.io/opct/must-gather-monitoring
+VERSION ?= $(shell git rev-parse --short HEAD)-$(shell date +%Y%m%d%H%M%S)
+
+.PHONY: all
+all: build-image
+
+.PHONY: build-image
+build-image:
+	@echo "\n>> Build image: $(IMAGE_NAME):$(VERSION)"
+	$(CMD_CNT) build -f Containerfile -t $(IMAGE_NAME):$(VERSION) .
+	@echo "Build success! When you are ready to push:"
+	@echo "export IMG=$(IMAGE_NAME):$(VERSION)"

--- a/must-gather-monitoring/README.md
+++ b/must-gather-monitoring/README.md
@@ -1,0 +1,157 @@
+# must-gather-monitoring
+
+The must-gather-monitoring collects metrics from monitoring
+stack (Prometheus) on OpenShift/OKD.
+
+The must-gather-monitoring container image is available in
+the repository `quay.io/opct/must-gather-monitoring`.
+
+OPCT runs the must-gather-monitoring in the collector plugin `99-openshift-artifacts-collector` (instance of `openshift-tests-provider-cert`).
+
+You can find the tarball file with the metrics collected by OPCT plugin in the following path of OPCT result tarball:
+`plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather-metrics.tar.xz`.
+
+## Usage
+
+### Exploring the metrics collected by OPCT
+
+1. Retrieve OPCT results
+
+```bash
+./opct retrieve
+```
+
+1. Extract the metrics from archive
+
+```bash
+tar xfz opct_archive.tar.gz plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather-metrics.tar.xz
+```
+
+1. Extract the compressed metrics
+
+```bash
+mkdir metrics-gather;
+tar xfJ plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather-metrics.tar.xz -C metrics-gather
+```
+
+1. Explore the metrics, each query are saved into a file:
+
+```bash
+$ ls metrics-gather/monitoring/prometheus/metrics/
+query_range-api-kas-request-duration-p99.json.gz     query_range-etcd-disk-fsync-wal-duration-p10.json.gz  query_range-etcd-total-leader-elections-day.json.gz
+query_range-api-kas-request-duration-p99.stderr      query_range-etcd-disk-fsync-wal-duration-p10.stderr   query_range-etcd-total-leader-elections-day.stderr
+
+```
+
+1. Explore the metrics data points
+
+```bash
+jq . $(zcat metrics-gather/monitoring/prometheus/metrics/query_range-api-kas-request-duration-p99.json.gz)
+```
+
+### Using as a standalone collector with must-gather
+
+#### Default execution
+
+```bash
+oc adm must-gather --image=quay.io/opct/must-gather-monitoring:devel
+```
+
+#### Customizing variables
+
+Use the following steps to run the must-gather directly replacing the default vars:
+
+1. Create the config map with queries to collect:
+
+```bash
+cat << EOF > ./collect-metrics.env
+GATHER_MONIT_START_DATE='6 hours ago'
+GATHER_MONIT_QUERY_STEP='1m'
+# API Request Duration by Verb - 99th Percentile [api-kas-request-duration-p99]
+declare -A OPT_GATHER_QUERY_RANGE=( [api-kas-request-duration-p99]='histogram_quantile(0.99, sum(resource_verb:apiserver_request_duration_seconds_bucket:rate:5m{apiserver="kube-apiserver"}) by (verb, le))' )
+EOF
+```
+
+2. Collect the metrics running must-gather
+
+```bash
+oc adm must-gather --image=quay.io/opct/must-gather-monitoring:devel -- /usr/bin/gather --use-cm "$ENV_POD_NAMESPACE"/must-gather-metrics
+```
+
+### Using as a standalone collector with sonobuoy plugin
+
+- Run
+```bash
+./opct sonobuoy run  -p ./plugin.yaml --dns-namespace=openshift-dns --dns-pod-labels=dns.operator.openshift.io/daemonset-dns=default
+```
+
+- Review the execution
+
+```bash
+./opct sonobuoy status
+oc get pods -n sonobuoy
+oc logs -n sonobuoy -f -c plugin -l sonobuoy-plugin=must-gather-monitoring
+oc logs -n sonobuoy -f -c sonobuoy-worker -l sonobuoy-plugin=must-gather-monitoring
+oc logs -n sonobuoy -f sonobuoy
+```
+
+- Wait the results to be ready by the server:
+
+```bash
+$ ./opct sonobuoy status
+
+                   PLUGIN     STATUS   RESULT   COUNT   PROGRESS
+   must-gather-monitoring   complete   passed       1           
+
+Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
+
+```
+
+- Collect the results
+
+```bash
+RESULT=$(./opct sonobuoy retrieve)
+./opct sonobuoy results $RESULT
+```
+
+- Review the results
+
+```bash
+$ ./opct sonobuoy results $RESULT
+Plugin: must-gather-monitoring
+Status: passed
+Total: 1
+Passed: 1
+Failed: 0
+Skipped: 0
+
+Run Details:
+API Server version: v1.27.4+2c83a9f
+Node health: 6/6 (100%)
+Pods health: 262/262 (100%)
+Errors detected in files:
+Warnings:
+73 podlogs/sonobuoy/sonobuoy/logs/kube-sonobuoy.txt
+```
+
+- Destroy tbe environment
+
+```bash
+./opct sonobuoy delete
+oc delete ns sonobuoy
+```
+
+
+## Build a container image
+
+1. Build the image:
+
+```bash
+make build-image
+```
+
+or to create a custom version:
+
+```bash
+make build-image VERSION=v0.1.0
+```

--- a/must-gather-monitoring/collection-scripts/gather
+++ b/must-gather-monitoring/collection-scripts/gather
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+
+#
+# Collect metrics data from Prometheus API.
+# See helper function (show_help|-h) for more information.
+#
+
+#Safeguards
+set -o pipefail
+set -o nounset
+set -o errexit
+
+function err_report {
+    echo "ERROR: on line $1 from ${0}"
+}
+trap 'err_report $LINENO' ERR
+
+# #######
+# DEFAULT
+# #######
+
+GATHER_MONIT_START_DATE='6 hours ago'
+GATHER_MONIT_QUERY_STEP='1m'
+
+# TODO: create default metrics by OCP Version
+
+# Dashboard (4.14): API Performance apiserver[kube-apiserver] period=[5m]:
+# API Request Duration by Verb - 99th Percentile [api-kas-request-duration-p99]
+declare -gA GATHER_PROM_QUERIES_RANGE=()
+declare -gA OPT_GATHER_QUERY_RANGE=()
+OPT_GATHER_QUERY_RANGE+=( [api-kas-request-duration-p99]='histogram_quantile(0.99, sum(resource_verb:apiserver_request_duration_seconds_bucket:rate:5m{apiserver="kube-apiserver"}) by (verb, le))' )
+OPT_GATHER_QUERY_RANGE+=( [etcd-request-duration-p99]='histogram_quantile(0.99, operation:etcd_request_duration_seconds_bucket:rate5m)' )
+
+# Dashboard (4.14): etcd cluster=[etcd]:
+OPT_GATHER_QUERY_RANGE+=( [etcd-disk-fsync-db-duration-p99]='histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m])) by (instance, le))' )
+OPT_GATHER_QUERY_RANGE+=( [etcd-disk-fsync-wal-duration-p99]='histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m])) by (instance, le))' )
+OPT_GATHER_QUERY_RANGE+=( [etcd-total-leader-elections-day]='changes(etcd_server_leader_changes_seen_total{job="etcd"}[1d])' )
+OPT_GATHER_QUERY_RANGE+=( [etcd-peer-round-trip-time]='histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m])))' )
+OPT_GATHER_QUERY_RANGE+=( [etcd-disk-fsync-wal-duration-p10]='histogram_quantile(0.1, sum by(instance, le) (irate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m])))' )
+OPT_GATHER_QUERY_RANGE+=( [etcd-disk-fsync-wal-duration-p50]='histogram_quantile(0.5, sum by(instance, le) (irate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m])))' )
+OPT_GATHER_QUERY_RANGE+=( [etcd-disk-fsync-wal-duration-p80]='histogram_quantile(0.8, sum by(instance, le) (irate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m])))' )
+
+# Dashboard (4.14): Kubernetes / Compute Resources / Cluster (by namespace)
+OPT_GATHER_QUERY_RANGE+=( [cluster-cpu-usage]='sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=""}) by (namespace)' )
+OPT_GATHER_QUERY_RANGE+=( [cluster-memory-usage-wo-cache]='sum(container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", container!=""}) by (namespace)' )
+OPT_GATHER_QUERY_RANGE+=( [cluster-storage-iops]='ceil(sum by(namespace) (rate(container_fs_reads_total{job="kubelet", metrics_path="/metrics/cadvisor", id!="", device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+", cluster="", namespace!=""}[5m]) + rate(container_fs_writes_total{job="kubelet", metrics_path="/metrics/cadvisor", id!="", cluster="", namespace!=""}[5m])))' )
+OPT_GATHER_QUERY_RANGE+=( [cluster-storage-throughput]='sum by(namespace) (rate(container_fs_reads_bytes_total{job="kubelet", metrics_path="/metrics/cadvisor", id!="", device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+", cluster="", namespace!=""}[5m]) + rate(container_fs_writes_bytes_total{job="kubelet", metrics_path="/metrics/cadvisor", id!="", cluster="", namespace!=""}[5m]))' )
+
+# Dashboard (4.14): Node Exporter  USE Method / Node
+OPT_GATHER_QUERY_RANGE+=( [node-cpu-saturation-load1]='(instance:node_load1_per_cpu:ratio{job="node-exporter", cluster=""} / scalar(count(instance:node_load1_per_cpu:ratio{job="node-exporter", cluster=""})))  != 0' )
+OPT_GATHER_QUERY_RANGE+=( [node-memory-saturation]='instance:node_vmstat_pgmajfault:rate1m{job="node-exporter", cluster=""}' )
+OPT_GATHER_QUERY_RANGE+=( [node-network-saturation-tx]='instance:node_network_transmit_drop_excluding_lo:rate1m{job="node-exporter", cluster=""} != 0' )
+OPT_GATHER_QUERY_RANGE+=( [node-network-saturation-rx]='instance:node_network_receive_drop_excluding_lo:rate1m{job="node-exporter", cluster=""} != 0' )
+OPT_GATHER_QUERY_RANGE+=( [node-disk-saturation]='( instance_device:node_disk_io_time_weighted_seconds:rate1m{job="node-exporter", cluster=""} / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate1m{job="node-exporter", cluster=""}))) != 0' )
+
+# ######
+# HELPER
+# ######
+
+# Receive a valid string and return as URL Encoded
+function url_encode {
+    echo -n "$@" | curl -Gso /dev/null -w '%{url_effective}' --data-urlencode @- "" | cut -c 3-
+}
+
+# Remove special chars from a string and return it
+function get_alphanum_str {
+    echo -n "$@" | tr -dc '[:alnum:]-_'
+}
+
+function echo_info {
+    echo "[$(date +%Y%M%d-%H%m%S)] INFO: $*"
+}
+
+function oc_get_with_ca {
+    "${OC_CLI[@]}" get \
+        --certificate-authority="${CA_BUNDLE}" \
+        --token="${SS_TOKEN}" \
+        "$@"
+}
+
+# ##############
+# PROMETHEUS API
+# ##############
+
+function prom_get_api {
+    oc_get_with_ca \
+        --server="https://${PROM_HOST}" \
+        --raw="${PROM_API_PATH}/${1}"
+}
+
+function prom_get_expression_query {
+
+    local api_expression="${1}"; shift
+    local metric_name="${1}"; shift
+    local query_param="${1}"; shift
+
+    # create a valid URL encoded query
+    local query
+    local req_query
+    query=$(url_encode "${query_param}")
+    req_query="${api_expression}?query=${query}&${PROM_API_QSTR}"
+
+    # create a valid filename (without special chars that comes from complex queries)
+    local file_basename="${metric_name}"
+    local file_base="${MG_METRICS_PATH}/${api_expression}-${file_basename}"
+    local file_ok="${file_base}.json.gz";
+    local file_err="${file_base}.stderr";
+
+    echo_info "Collecting query /${api_expression}?query=${query}"
+    if [[ ! -f "${MG_PROM_PATH}/${api_expression}.log" ]]; then
+        echo "file_path_prefix;req_expression_query" > "${MG_PROM_PATH}/${api_expression}.log"
+    fi
+    echo "${file_base};${req_query}" >> "${MG_PROM_PATH}/${api_expression}.log"
+
+    prom_get_api "${req_query}" 2> "${file_err}" | gzip > "${file_ok}"
+}
+
+#
+# Gather a query from a valid expression
+# Env var: GATHER_PROM_QUERIES
+#
+function get_query {
+
+    if [[ ${#GATHER_PROM_QUERIES[*]} -le 0 ]]; then
+        echo_info "No queries was found to collect from env GATHER_PROM_QUERIES"
+        return
+    fi
+    mkdir -p "${MG_METRICS_PATH}"
+
+    echo_info "Collecting instant queries..."
+
+    for name in "${!GATHER_PROM_QUERIES[*]}"; do
+        query=${GATHER_PROM_QUERIES[$name]}
+        prom_get_expression_query "query" "${name}" "${query}" || true
+    done
+}
+
+#
+# Gather a query range from a valid expression
+# Env var: GATHER_PROM_QUERIES_RANGE
+#
+function get_query_range {
+
+    if [[ -f /must-gather/monitoring/env ]]; then
+        set -x
+        echo "[get_query_range] Loading configuration /must-gather/monitoring/env"
+        set +x
+    fi
+    if [[ ${#OPT_GATHER_QUERY_RANGE[*]} -le 0 ]]; then
+        echo_info "No queries was found to collect from env OPT_GATHER_QUERY_RANGE"
+        return
+    fi
+    mkdir -p "${MG_METRICS_PATH}"
+
+    echo_info "Collecting queries range..."
+
+    for name in ${!OPT_GATHER_QUERY_RANGE[*]}; do
+        query=${OPT_GATHER_QUERY_RANGE[$name]}
+        prom_get_expression_query "query_range" "${name}" "${query}" || true
+    done
+    set +x
+}
+
+#
+# Discovery and gather metrics by prefixes.
+# Env var: GATHER_PROM_QUERIES_RANGE_PREFIX
+#
+# function get_query_range_discovery {
+
+#     if [[ ${#GATHER_PROM_QUERIES_RANGE_PREFIX[*]} -le 0 ]]; then
+#         echo_info "No metrics was found to collect from env GATHER_PROM_QUERIES_RANGE_PREFIX"
+#         return
+#     fi
+#     echo_info "Collecting metrics by prefixes..."
+#     mkdir -p "${MG_METRICS_PATH}"
+
+#     # dump current available metrics to discovery/filter desired as defined on env var
+#     prom_get_api "label/__name__/values" \
+#         | python2 -c '\
+#                 import json,sys;\
+#                 v=[];\
+#                 [ v.append(d) for d in json.load(sys.stdin)["data"] ];\
+#                 print( "\n".join(v) );\
+#             ' > "${MG_PROM_PATH}/prometheus-metrics.txt"
+
+#     # lookup metrics into current dump
+#     while read metric; do
+#         for name in "${!GATHER_PROM_QUERIES_RANGE_PREFIX[*]}"; do
+#             prefix=${GATHER_PROM_QUERIES_RANGE_PREFIX[$name]}
+#             if [[ "${metric}" =~ ^${prefix}.* ]]; then
+#                 prom_get_expression_query "query_range" "${metric}" "${metric}" || true
+#             fi
+#         done
+#     done < "${MG_PROM_PATH}/prometheus-metrics.txt"
+# }
+
+# #####
+# SETUP
+# #####
+
+function cleanup {
+    rm "${CA_BUNDLE}"
+}
+
+# this is a CA bundle we need to verify the monitoring route,
+# we will write it to disk so we can use it in the flag
+function get_ca_bundle {
+    "${OC_CLI[@]}" -n openshift-config-managed \
+        get cm default-ingress-cert \
+        -o jsonpath='{.data.ca-bundle\.crt}' > "${CA_BUNDLE}"
+}
+
+# Handle configuration from ConfigMap (less precedence than CLI)
+function set_env_from_config {
+
+    if [[ ${OPT_CONFIG} == false ]]; then return; fi
+
+    # parse cm from 'namespace/configMapName' to 'cm_namespace' and 'cm_name'
+    local cm_namespace
+    local cm_name
+    cm_namespace=$(echo "${OPT_CONFIG_NAME}" | awk -F'/' '{print$1}')
+    cm_name=$(echo "${OPT_CONFIG_NAME}" | awk -F'/' '{print$2}')
+
+    "${OC_CLI[@]}" -n "${cm_namespace}" \
+        extract "cm/${cm_name}" \
+        --keys=env \
+        --confirm \
+        --to="${MG_MONITORING_PATH}/" >/dev/null 2>&1
+
+    echo_info "Get custom metrics from ConfigMap ${cm_name} on project ${cm_namespace}"
+    if [[ -s "${MG_MONITORING_PATH}/env" ]]; then
+        echo_info "Loading custom environments variables from ${MG_MONITORING_PATH}/env"
+        eval "$(cat "${MG_MONITORING_PATH}/env")"
+        cat "${MG_MONITORING_PATH}/env"
+    else
+        echo_info "Unable to load custom environments from ConfigMap, ignoring."
+    fi
+}
+
+# Handle configuration from CLI args (more precedence than CM)
+# function set_env_from_cli {
+
+#     echo "OPT_GATHER_QUERY=${!OPT_GATHER_QUERY[*]}"
+#     if [[ -n "${OPT_GATHER_QUERY}" ]]; then
+#         for name in "${!OPT_GATHER_QUERY[*]}"; do
+#             GATHER_PROM_QUERIES[${name}]=${OPT_GATHER_QUERY[${name}]}
+#         done
+#     fi
+
+#     echo "OPT_GATHER_QUERY_RANGE=${!OPT_GATHER_QUERY_RANGE[*]}"
+#     if [[ ${#OPT_GATHER_QUERY_RANGE[*]} -gt 0 ]]; then
+#         for name in "${!OPT_GATHER_QUERY_RANGE[*]}"; do
+#             GATHER_PROM_QUERIES_RANGE[${name}]=${OPT_GATHER_QUERY_RANGE[${name}]}
+#         done
+#     fi
+# }
+
+function set_env_default {
+
+    # declare -g OPT_VERBOSE=false
+    # declare -g OPT_DEBUG=false
+    declare -g OPT_CONFIG=false
+    declare -g OPT_CONFIG_NAME
+
+    declare -g GATHER_BASE_PATH_DEFAULT="/must-gather"
+    declare -g GATHER_MONIT_START_DATE_DEFAULT="6 hours ago"
+    declare -g GATHER_MONIT_END_DATE_DEFAULT="now"
+    declare -g GATHER_MONIT_QUERY_STEP_DEFAULT="1m"
+
+    declare -g OC_REQUEST_TIMEOUT_DEFAULT="15s"
+
+    declare -gA GATHER_PROM_QUERIES=()
+    declare -gA GATHER_PROM_QUERIES_RANGE=()
+    declare -gA GATHER_PROM_QUERIES_RANGE_PREFIX=()
+}
+
+function init_env {
+
+    declare -g PROM_API_PATH="/api/v1"
+
+    declare -g MG_BASE_PATH="${GATHER_BASE_PATH_DEFAULT:-"/must-gather"}"
+    declare -g MG_MONITORING_PATH="${MG_BASE_PATH}/monitoring"
+    declare -g MG_PROM_PATH="${MG_MONITORING_PATH}/prometheus"
+    declare -g MG_METRICS_PATH="${MG_PROM_PATH}/metrics"
+    declare -g CA_BUNDLE="${MG_MONITORING_PATH}/ca-bundle.crt"
+
+    declare -g OC_CLI=()
+    OC_CLI+=(/usr/bin/oc)
+    OC_CLI+=("--request-timeout=${OC_REQUEST_TIMEOUT_DEFAULT}")
+}
+
+function init {
+
+    init_env
+    mkdir -p "${MG_MONITORING_PATH}"
+
+    # Set Configurations from dynamic sources (CM or CLI)
+    set_env_from_config
+    # set_env_from_cli
+
+    # Cache default ingress CA
+    get_ca_bundle
+
+    # Session token, overwriten by GATHER_MONIT_TOKEN
+    declare -g SS_TOKEN
+    SS_TOKEN="${GATHER_MONIT_TOKEN:-$("${OC_CLI[@]}" whoami -t)}"
+
+    # prometheus-k8s | thanos-querier : TODO need to validate thanos-querier endpoints is compatible
+    local prom_route_name="${PROM_ROUTE_NAME:-"prometheus-k8s"}"
+    declare -g PROM_HOST
+    PROM_HOST=$("${OC_CLI[@]}" -n openshift-monitoring get route "${prom_route_name}" -o jsonpath='{.spec.host}{"\n"}')
+
+    # Query Param: 'start' and 'end' timestamp
+    local date_start_human=${GATHER_MONIT_START_DATE:-${GATHER_MONIT_START_DATE_DEFAULT}}
+    local date_end_human=${GATHER_MONIT_END_DATE:-${GATHER_MONIT_END_DATE_DEFAULT}}
+    declare -g DATE_START
+    declare -g DATE_END
+    DATE_START=$(date -d "${date_start_human}" +%s)
+    DATE_END=$(date -d "${date_end_human}" +%s)
+
+    # Query Param: 'step'. Low metric resolution with long range could be limited to 11k datapoints.
+    declare -g QUERY_STEP=${GATHER_MONIT_QUERY_STEP:-${GATHER_MONIT_QUERY_STEP_DEFAULT}}
+
+    declare -g PROM_API_QSTR="start=${DATE_START}&end=${DATE_END}&step=${QUERY_STEP}"
+
+    # Dump loaded config
+    cat <<-EOF
+INFO: Metrics config time range from=${DATE_START} to=${DATE_END} step=${QUERY_STEP}
+INFO: Metrics human  time range from=[$(date -d "@${DATE_START}")] to [$(date -d "@${DATE_END}")]
+INFO: Config Env GATHER_MONIT_START_DATE: ${GATHER_MONIT_START_DATE:-""}
+INFO: Config Env GATHER_MONIT_END_DATE: ${GATHER_MONIT_END_DATE:-""}
+INFO: Config Env GATHER_MONIT_QUERY_STEP: ${GATHER_MONIT_QUERY_STEP:-""}
+INFO: Config Env GATHER_PROM_QUERIES: ${GATHER_PROM_QUERIES:-""}
+INFO: Config Env GATHER_PROM_QUERIES_RANGE: ${GATHER_PROM_QUERIES_RANGE:-""}
+INFO: Config Env GATHER_PROM_QUERIES_RANGE_PREFIX: ${GATHER_PROM_QUERIES_RANGE_PREFIX:-""}
+INFO: Prometheus endpoint: https://${PROM_HOST}
+INFO: Prometheus base query: ${PROM_API_PATH}/<expression>?query=<metric>&${PROM_API_QSTR}"
+EOF
+}
+
+# ####
+# MAIN
+# ####
+function show_help {
+
+    cat <<-EOF
+Usage: ${0} [options]
+
+Available options:
+    -h | --help                 Show this help
+    -c | --use-cm  ns/cm_name   Specify the ConfigMap to load environment variables on the
+                                format namespace/configMapName. Default is: None (load From variables)
+    -s | --start-date date_str  Start date string. Default is: ${GATHER_MONIT_START_DATE_DEFAULT}
+    -e | --end-date date_str    End date string. Default is: ${GATHER_MONIT_END_DATE_DEFAULT}
+    -S | --step duration        Query resolution step width in 'duration' format or float
+                                number of seconds. Default is: ${GATHER_MONIT_QUERY_STEP_DEFAULT}
+    -o | --dest-dir path        Set a specific directory on the local machine to write gathered data to.
+    -t | --timeout value        The length of time to gather data, in seconds. Default is: ${OC_REQUEST_TIMEOUT_DEFAULT}
+    --endpoint (API|tsdb)       TODO. Endpoint to be created, API queries or chunks from TSDB. Default: API.
+    --query PromQuery           Prometheus Query to collect instant query
+    --query-range PromQuery     Prometheus Query to collect time range
+    --query-range-prefix Query  Prometheus Query range prefix to be discovered and collected.
+
+Available environments variables to be used on ConfigMap:
+    GATHER_BASE_PATH_DEFAULT="${GATHER_BASE_PATH_DEFAULT}"
+
+    # Query setup
+    GATHER_MONIT_START_DATE="${GATHER_MONIT_START_DATE_DEFAULT}"
+    GATHER_MONIT_END_DATE="${GATHER_MONIT_END_DATE_DEFAULT}"
+    GATHER_MONIT_QUERY_STEP="${GATHER_MONIT_QUERY_STEP_DEFAULT}"
+
+    # Queries
+    GATHER_PROM_QUERIES=()
+    GATHER_PROM_QUERIES_RANGE=()
+    GATHER_PROM_QUERIES_RANGE_PREFIX=()
+
+Examples:
+    # Simple collect simple query
+    ${0} --query "up"
+
+    # Simple collect simple query and save to a custom directory
+    ${0} --query "up" --dest-dir ./monitoring-metrics
+
+    # Query range collector from last hour
+    ${0} -s "1 hours ago" -e "now" -o metrics-1h --query-range "up"
+
+    # Query range collector from last hour of metrics with prefix name "etcd_disk_"
+    ${0} -s "1 hours ago" -e "now" -o metrics-1h-prefix --query-range-prefix "etcd_disk_"
+
+    # Create a ConfigMap to store variables
+    echo "GATHER_MONIT_START_DATE='12 hours ago'
+GATHER_MONIT_QUERY_STEP='1m'
+GATHER_PROM_QUERIES=('up')
+GATHER_PROM_QUERIES_RANGE='instance:node_load1_per_cpu:ratio
+changes(etcd_server_leader_changes_seen_total[1h])'
+GATHER_PROM_QUERIES_RANGE_PREFIX='etcd_disk_
+apiserver_flowcontrol'" > ./env
+    oc create configmap must-gather-metrics-env -n mgm --from-file=env=env
+    ${0} --use-cm mgm/must-gather-metrics-env
+
+EOF
+
+}
+
+function main {
+
+    init
+
+    # Gather a query
+    get_query
+
+    # Gather a query range
+    get_query_range
+
+    # Gather a query range by prefix (discovery)
+    #get_query_range_discovery
+
+    # force disk flush to ensure that all data gathered is accessible in the copy container
+    cleanup
+    sync
+
+    echo_info "Done"
+}
+
+function main_cli {
+
+    # NOTE: This requires GNU getopt.
+    # '-> On Mac OS X and FreeBSD need to be installed as: brew install gnu-getopt
+    if ! eval set -- "$(getopt -n 'gather-monitoring-data' -o hvdc:s:e:S:o:t: \
+            --long verbose,debug,help,use-cm:,start-date:,end-date:,step:,path:,dest-dir:,timeout:,query:,query-range:,query-range-prefix: \
+            -- "$@")"; then
+        echo "gnu-getopt seems not to be present. Please install it. Terminating..." >&2 ;
+        exit 1 ;
+    fi
+    # eval set -- "${GETOPT_SET}"
+
+    set_env_default
+    while true; do
+        case "$1" in
+            -h | --help         ) show_help; exit 2 ;;
+            # -v | --verbose      ) OPT_VERBOSE=true; shift ;;
+            # -d | --debug        ) OPT_DEBUG=true; shift ;;
+            -c | --use-cm       ) OPT_CONFIG=true; OPT_CONFIG_NAME="$2"; shift 2 ;;
+            -s | --start-date   ) GATHER_MONIT_START_DATE_DEFAULT="$2"; shift 2 ;;
+            -e | --end-date     ) GATHER_MONIT_END_DATE_DEFAULT="$2"; shift 2 ;;
+            -S | --step         ) GATHER_MONIT_QUERY_STEP_DEFAULT="$2"; shift 2 ;;
+            -o | --dest-dir     ) GATHER_BASE_PATH_DEFAULT="$2"; shift 2 ;;
+            -t | --timeout      ) OC_REQUEST_TIMEOUT_DEFAULT="$2"; shift 2 ;;
+            # --query             ) OPT_GATHER_QUERY="$2"; shift 2 ;;
+            # --query-range       ) OPT_GATHER_QUERY_RANGE="$2"; shift 2 ;;
+            # --query-range-prefix) OPT_GATHER_QUERY_RANGE_PREFIX="$2"; shift 2 ;;
+            -- ) shift; break ;;
+            * ) echo "Option not found"; break ;;
+        esac
+    done
+
+    main
+    echo "Done"
+}
+
+main_cli "$@"

--- a/must-gather-monitoring/plugin.yaml
+++ b/must-gather-monitoring/plugin.yaml
@@ -1,0 +1,22 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: must-gather-monitoring
+  result-format: raw
+  source_url: https://raw.githubusercontent.com/redhat-ecosystem/provider-certification-plugins/main/must-gather-monitoring/plugin.yaml
+  description: A quickly way to collect Prometheus Metrics on OpenShift/OKD clusters.
+spec:
+  name: plugin
+  image: quay.io/opct/must-gather-monitoring:v0.1.0
+  imagePullPolicy: Always
+  command:
+  - bash
+  -  /usr/bin/runner_plugin
+  env:
+  - name: IMAGE_VERSION
+    value: "v0.1.0"
+  - name: RESULTS_PATH
+    value: /tmp/sonobuoy/results
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/sonobuoy/results
+    name: results

--- a/must-gather-monitoring/runner_plugin
+++ b/must-gather-monitoring/runner_plugin
@@ -1,0 +1,13 @@
+#!/bin/env bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+set -x
+
+cd /tmp
+oc adm must-gather --dest-dir=must-gather-metrics --image=quay.io/opct/must-gather-monitoring:"${IMAGE_VERSION}"
+
+cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html must-gather-metrics/*/monitoring/
+tar cfJ "${RESULTS_PATH}/artifacts_must-gather-metrics.tar.xz" -C must-gather-metrics/*/ monitoring/
+echo "${RESULTS_PATH}/artifacts_must-gather-metrics.tar.xz" > /tmp/sonobuoy/results/done

--- a/openshift-tests-provider-cert/plugin/global_env.sh
+++ b/openshift-tests-provider-cert/plugin/global_env.sh
@@ -54,12 +54,12 @@ declare -grx OPENSHIFT_TESTS_SUITE_UPGRADE="none"
 ## openshift-kube-conformance
 declare -grx PLUGIN_ID_KUBE_CONFORMANCE="10"
 declare -grx PLUGIN_NAME_KUBE_CONFORMANCE="${PLUGIN_ID_KUBE_CONFORMANCE}-openshift-kube-conformance"
-declare -grx OPENSHIFT_TESTS_SUITE_KUBE_CONFORMANCE="kubernetes/conformance"
+declare -grx OPENSHIFT_TESTS_SUITE_KUBE_CONFORMANCE="${PLUGIN_SUITE_KUBE_CONFORMANCE:-kubernetes/conformance}"
 
 ## openshift-conformance-validated
 declare -grx PLUGIN_ID_OPENSHIFT_CONFORMANCE="20"
 declare -grx PLUGIN_NAME_OPENSHIFT_CONFORMANCE="${PLUGIN_ID_OPENSHIFT_CONFORMANCE}-openshift-conformance-validated"
-declare -grx OPENSHIFT_TESTS_SUITE_OPENSHIFT_CONFORMANCE="openshift/conformance"
+declare -grx OPENSHIFT_TESTS_SUITE_OPENSHIFT_CONFORMANCE="${PLUGIN_SUITE_OPENSHIFT_CONFORMANCE:-openshift/conformance}"
 
 ## openshift-artifacts-collector
 declare -grx PLUGIN_ID_OPENSHIFT_ARTIFACTS_COLLECTOR="99"

--- a/openshift-tests-provider-cert/plugin/global_fn.sh
+++ b/openshift-tests-provider-cert/plugin/global_fn.sh
@@ -5,7 +5,7 @@
 # os_log_info logger function, printing the current bash script
 # and line as prefix.
 os_log_info() {
-    echo "$(date +%Y-%m-%d_%H:%M:%S) | [${SERVICE_NAME}] | $(caller | awk '{print$2":"$1}')> " "$@"
+    echo "$(date --iso-8601=seconds) | [${SERVICE_NAME}] | $(caller | awk '{print$2":"$1}')> " "$@"
 }
 export -f os_log_info
 

--- a/openshift-tests-provider-cert/plugin/wait-plugin.sh
+++ b/openshift-tests-provider-cert/plugin/wait-plugin.sh
@@ -6,7 +6,7 @@ set -o nounset
 # set -o errexit
 
 os_log_info_local() {
-    os_log_info "$(date +%Y%m%d-%H%M%S)> [waiter] $*"
+    os_log_info "[waiter] $*"
 }
 
 os_log_info_local "Starting Level[${PLUGIN_ID:-}]..."
@@ -19,8 +19,9 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
         os_log_info_local "Waiting for pod running with label: ${pod_label}"
         kubectl wait \
             --namespace "${ENV_POD_NAMESPACE:-sonobuoy}" \
-            --timeout=10m \
+            --timeout=3m \
             --for=condition=ready pod \
+            --field-selector=status.phase!=Succeeded \
             -l sonobuoy-plugin="${pod_label}"
     done
 
@@ -43,7 +44,7 @@ if [[ ${#PLUGIN_BLOCKED_BY[@]} -ge 1 ]]; then
             plugin_status=$(jq -r ".plugins[] | select (.plugin == \"${bl_plugin_name}\" ) |.status // \"\"" "${STATUS_FILE}")
 
             os_log_info_local "Plugin[${bl_plugin_name}] with status[${plugin_status}]..."
-            os_log_info_local "$(cat "${STATUS_FILE}")"
+            # os_log_info_local "$(cat "${STATUS_FILE}")" #> used in debug situations only
             if [[ "${plugin_status}" == "${SONOBUOY_PLUGIN_STATUS_COMPLETE}" ]] || [[ "${plugin_status}" == "${SONOBUOY_PLUGIN_STATUS_FAILED}" ]]; then
                 os_log_info_local "Plugin[${bl_plugin_name}] with status[${plugin_status}] is completed!"
                 break


### PR DESCRIPTION
Introduce a must-gather-like collector to extract metrics from Prometheus.

The image for the custom must-gather (must-gather-monitoring) will be triggered by the artifact collector plugin, compacting all the metrics into a single compressed tarball file.

The metrics collected by default are extracted from the main widgets in the OCP Dashboards, prioritizing elaborated expressions to save storage in client side, and CPU and Memory in the server side.

The total of storage incremented in the final tarball file are less than 1MiB in the samples collected. o/

There are no tool to read and process the raw metrics yet, but it can be consumed in the future by the OPCT report or use opensource projects to load/back fill prometheus db to read it in the monitoring-like tools (anyone that requires lower development effort would be preferred). 

Additional storage for default metrics collected:

```bash
$ ls -sh results/plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather-metrics.tar.xz
464K results/plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather-metrics.tar.xz
$ tar xfJ results/plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather-metrics.tar.xz -C metrics/
$ du -sh metrics/
532K	metrics/
$ tree metrics/
metrics/
└── monitoring
    ├── event-filter.html
    ├── prometheus
    │   ├── metrics
    │   │   ├── query_range-api-kas-request-duration-p99.json.gz
    │   │   ├── query_range-api-kas-request-duration-p99.stderr
    │   │   ├── query_range-cluster-cpu-usage.json.gz
    │   │   ├── query_range-cluster-cpu-usage.stderr
    │   │   ├── query_range-cluster-memory-usage-wo-cache.json.gz
    │   │   ├── query_range-cluster-memory-usage-wo-cache.stderr
    │   │   ├── query_range-cluster-storage-iops.json.gz
    │   │   ├── query_range-cluster-storage-iops.stderr
    │   │   ├── query_range-cluster-storage-throughput.json.gz
    │   │   ├── query_range-cluster-storage-throughput.stderr
    │   │   ├── query_range-etcd-disk-fsync-db-duration-p99.json.gz
    │   │   ├── query_range-etcd-disk-fsync-db-duration-p99.stderr
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p10.json.gz
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p10.stderr
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p50.json.gz
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p50.stderr
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p80.json.gz
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p80.stderr
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p99.json.gz
    │   │   ├── query_range-etcd-disk-fsync-wal-duration-p99.stderr
    │   │   ├── query_range-etcd-peer-round-trip-time.json.gz
    │   │   ├── query_range-etcd-peer-round-trip-time.stderr
    │   │   ├── query_range-etcd-request-duration-p99.json.gz
    │   │   ├── query_range-etcd-request-duration-p99.stderr
    │   │   ├── query_range-etcd-total-leader-elections-day.json.gz
    │   │   ├── query_range-etcd-total-leader-elections-day.stderr
    │   │   ├── query_range-node-cpu-saturation-load1.json.gz
    │   │   ├── query_range-node-cpu-saturation-load1.stderr
    │   │   ├── query_range-node-disk-saturation.json.gz
    │   │   ├── query_range-node-disk-saturation.stderr
    │   │   ├── query_range-node-memory-saturation.json.gz
    │   │   ├── query_range-node-memory-saturation.stderr
    │   │   ├── query_range-node-network-saturation-rx.json.gz
    │   │   ├── query_range-node-network-saturation-rx.stderr
    │   │   ├── query_range-node-network-saturation-tx.json.gz
    │   │   └── query_range-node-network-saturation-tx.stderr
    │   └── query_range.log
    └── timestamp
```

https://issues.redhat.com/browse/OPCT-246