### PR TITLE
OPCT-213: Backport #43 | update base image for 4.14

### DIFF
--- a/openshift-tests-provider-cert/hack/Containerfile.tools-alp
+++ b/openshift-tests-provider-cert/hack/Containerfile.tools-alp
@@ -15,24 +15,25 @@ FROM ${CONTAINER_BASE} as base
 
 # gcompat: allow to run glibc programs (oc and jq)
 # sononbuoy is already built with musl
-RUN apk add --no-cache --update \
-    bash curl grep gcompat xz
+RUN microdnf install -y bash curl grep tar xz gzip && \
+    microdnf clean all
 
 FROM base as clients
 WORKDIR /clients
 
 ADD https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/${VERSION_OC}/openshift-client-linux.tar.gz ./
-ADD https://stedolan.github.io/jq/download/linux64/jq ./
-RUN apk add --no-cache --update tar binutils \
+ADD https://github.com/jqlang/jq/releases/download/jq-1.4/jq-linux-x86_64 ./
+RUN microdnf install -y binutils \
     && tar xvfz openshift-client-linux.tar.gz \
     && rm -f openshift-client-linux.tar.gz kubectl README.md \
     && chmod +x jq oc \
+    && chmod +x jq-linux-x86_64 oc \
     && strip oc
 
 #
 ## ocp-etcd-log-filters builder
 #
-FROM golang:1.19-alpine as oelf-builder
+FROM ${CONTAINER_BASE_GOBUILD} as oelf-builder
 
 COPY cmd/ocp-etcd-log-filters/*.go $GOPATH/src/github.com/opct/plugins/
 WORKDIR $GOPATH/src/github.com/opct/plugins/
@@ -50,7 +51,7 @@ LABEL io.k8s.display-name="OpenShift Tests for Provider Certification Tools" \
 WORKDIR /tools
 COPY --from=sonobuoy /sonobuoy /usr/bin/
 COPY --from=clients /clients/oc /usr/bin/
-COPY --from=clients /clients/jq /usr/bin/
+COPY --from=clients /clients/jq-linux-x86_64 /usr/bin/jq
 COPY --from=oelf-builder /usr/bin/ocp-etcd-log-filters /usr/bin/
 RUN ln -svf /usr/bin/oc /usr/bin/kubectl
 

--- a/openshift-tests-provider-cert/hack/build-image.sh
+++ b/openshift-tests-provider-cert/hack/build-image.sh
@@ -23,16 +23,18 @@ VERSION_PLUGIN_DEVEL="${VERSION_DEVEL:-}";
 FORCE="${FORCE:-false}";
 
 # TOOLS version is created by suffix of oc and sonobuoy versions w/o dots
-export VERSION_TOOLS="v0.0.0-alp3165-oc4121-s05612-v0"
-export CONTAINER_BASE="alpine:3.16.5"
-export VERSION_OC="4.12.1"
+export CONTAINER_BASE_GOBUILD="golang:1.19-alpine"
+export CONTAINER_BASE_BUILD="alpine:3.16.5"
+export CONTAINER_BASE="quay.io/fedora/fedora-minimal:38-x86_64"
+export VERSION_TOOLS="v0.1.0"
+export VERSION_OC="4.13.3"
 export VERSION_SONOBUOY="v0.56.12"
 
 IMAGE_PLUGIN="${REGISTRY_PLUGIN}/openshift-tests-provider-cert"
 IMAGE_TOOLS="${REGISTRY_TOOLS}/tools"
-IMAGE_SONOBUOY="docker.io/sonobuoy/sonobuoy"
+IMAGE_SONOBUOY_MIRROR="docker.io/sonobuoy/sonobuoy"
 
-export CONTAINER_SONOBUOY="${IMAGE_SONOBUOY}:${VERSION_SONOBUOY}"
+export CONTAINER_SONOBUOY="${IMAGE_SONOBUOY_MIRROR}:${VERSION_SONOBUOY}"
 export CONTAINER_SONOBUOY_MIRROR="${REGISTRY_MIRROR}/sonobuoy:${VERSION_SONOBUOY}"
 export CONTAINER_TOOLS="${IMAGE_TOOLS}:${VERSION_TOOLS}"
 export CONTAINER_PLUGIN="${IMAGE_PLUGIN}:${VERSION_PLUGIN}"


### PR DESCRIPTION
Backport #43 on v0.4 to support OCP 4.14.

The intention is to create v0.4.1 while v0.5 is not yet release as there are folks using OPCT in OCP 4.14 outside of the development.