### PR TITLE
OPCT-devel: openshift-tests replay plugin

### DIFF
--- a/openshift-tests-replay/README.md
+++ b/openshift-tests-replay/README.md
@@ -1,0 +1,89 @@
+# Run openshigt-tests replay plugin
+
+Standalone plugin to replay custom e2e tests using `openshift-tests` using opct/sonobuoy plugin workflow.
+
+Steps:
+
+- Export KUBECONFIG
+
+- Create replay file
+
+> The tests must have double brackets sepparated by line
+
+```sh
+cat << EOF > ./example-replay.txt
+"[sig-api-machinery] CustomResourceDefinition Watch [Privileged:ClusterAdmin] CustomResourceDefinition Watch watch on custom resource definition objects [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]"
+EOF
+```
+
+- Download the Plugin spec (devel path):
+
+```sh
+wget -qO /tmp/replay-plugin.yaml https://raw.githubusercontent.com/mtulio/provider-certification-plugins/plugin-openshift-tests-replay/openshift-tests-replay/plugin.yaml
+```
+
+- Create ConfigMap
+
+> The key must be `replay.list`
+
+```sh
+oc create ns tmp-opct
+oc create configmap -n tmp-opct openshift-tests-replay --from-file=replay.list=./example-replay.txt
+```
+
+- Run plugin
+
+```sh
+opct-devel sonobuoy run \
+    -p /tmp/replay-plugin.yaml  \
+    --plugin-env openshift-tests-replay.REPLAY_NAMESPACE=tmp-opct \
+    --plugin-env openshift-tests-replay.REPLAY_CONFIG=openshift-tests-replay \
+    --dns-namespace=openshift-dns \
+    --dns-pod-labels=dns.operator.openshift.io/daemonset-dns=default
+```
+
+- Check the status:
+
+```sh
+oc get pods -n sonobuoy -w
+opct-devel sonobuoy status
+```
+
+- Follow the execution:
+
+```sh
+oc logs -n sonobuoy -l sonobuoy-plugin=openshift-tests-replay -f -c plugin
+```
+
+- Collect the results when it finished
+
+> Note 1) Wait for sonobuoy clean the message `Preparing results for download.` on `status`: `watch -n 5 opct-devel sonobuoy status`
+
+> Note 2) Retry when getting the error `error retrieving results: unexpected EOF`
+
+
+```sh
+opct-devel sonobuoy retrieve
+```
+
+- Check the results
+
+```sh
+opct-devel sonobuoy results -m dump tarball.tgz
+```
+
+- Explore the logs
+
+```sh
+mkdir -p /tmp/plugin-replay-res
+tar xfz tarball.tgz -C /tmp/plugin-replay-res
+```
+
+- Read the documentation to understand [the directory structure](https://redhat-openshift-ecosystem.github.io/provider-certification-tool/troubleshooting-guide/#review-results-archive)
+
+- Destroy the environment
+
+```sh
+opct-devel sonobuoy delete
+oc delete ns tmp-opct
+```

--- a/openshift-tests-replay/plugin.yaml
+++ b/openshift-tests-replay/plugin.yaml
@@ -1,0 +1,60 @@
+config-map:
+  replay-runner.sh: |
+    declare -gxr SERVICE_NAME="plugin"
+    # shellcheck disable=SC1091
+    source ./global_env.sh
+    # shellcheck disable=SC1091
+    source ./global_fn.sh
+
+    os_log_info "logging to the cluster..."
+    openshift_login
+
+    os_log_info "starting utilities extractor..."
+    start_utils_extractor
+
+    # extract custom tests to replay
+    ${UTIL_OC_BIN} extract configmap/${REPLAY_CONFIG} -n ${REPLAY_NAMESPACE} --to=/tmp --keys=replay.list
+    cat /tmp/replay.list
+
+    # run openshift-tests
+    echo "Running openshift-tests"
+    ${UTIL_OTESTS_BIN} run openshift/conformance -f /tmp/replay.list --max-parallel-tests 1 --junit-dir=/tmp/junits --monitor node-state-analyzer
+
+    # save the results
+    echo "Collecting data"
+    mkdir /tmp/final
+    cp -v /tmp/junits/junit_*.xml /tmp/final/
+    tar cfz /tmp/final/junit_raw.tgz /tmp/junits/*
+
+    echo "Sending results to sonobuoy"
+    cd /tmp/final/ && tar cfz /tmp/sonobuoy/results/results.tar.gz *
+    echo "/tmp/sonobuoy/results/results.tar.gz" > /tmp/sonobuoy/results/done
+sonobuoy-config:
+  driver: Job
+  plugin-name: openshift-tests-replay
+  result-format: junit
+  source_url: https://raw.githubusercontent.com/redhat-ecosystem/provider-certification-plugins/main/openshift-tests-replay/plugin.yaml
+  description: Replay custom tests using openshift-tests on OpenShift/OKD clusters.
+spec:
+  name: plugin
+  image: quay.io/opct/plugin-openshift-tests:v0.5.0-alpha.3
+  imagePullPolicy: Always
+  command:
+  - bash
+  - /tmp/sonobuoy/config/replay-runner.sh
+  env:
+  - name: RESULTS_PATH
+    value: /tmp/sonobuoy/results
+  resources:
+    requests:
+      memory: "4096Mi"
+  nodeSelector: 
+    node-role.kubernetes.io/tests: ""
+  tolerations: 
+    - key: "node-role.kubernetes.io/tests"
+      operator: "Equal"
+      value: ""
+      effect: "NoSchedule"
+  volumeMounts:
+  - mountPath: /tmp/sonobuoy/results
+    name: results


### PR DESCRIPTION
Introduce a ephemeral plugin to allow users to run standalone executions replaying custom tests.