### PR TITLE
OPCT-257: fixes ci workflow preventing release deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 ---
-name: CI Plugin workflow
+name: release-tag
 on: 
   pull_request:
   push:
@@ -28,119 +28,12 @@ jobs:
           path: './openshift-tests-provider-cert/hack/*.sh'
 
 #
-# Build container image
-#
-  build-container:
-    name: release container(devel)
-    if: ${{ github.event_name == 'pull_request' &&  github.base_ref == 'main' }}
-    runs-on: ubuntu-22.04
-    needs: [linters]
-    env:
-      VERSION: "v0.0.0-devel-pr.${{ github.event.pull_request.number }}"
-      TOOLS_REPO: localhost/tools
-      PLUGIN_TESTS_REPO: localhost/plugin-openshift-tests
-      MGM_REPO: localhost/must-gather-monitoring
-
-    environment: production
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Build images x86_64
-        shell: bash
-        run: |
-          echo "> Build and publish container image:"
-          make build-arch-amd64 VERSION=${VERSION}
-
-      # # TODO1: arm64 environment on Github Actions is not working.
-      # # manual steps is required:
-      # # $ make build-arch-arm64 VERSION=${VERSION}
-      # # $ make push-manifests VERSION=${VERSION}
-      #
-      # # TODO2: Quay login is not working for newer steps. Secrets are returning empty values.
-      #
-      # image is not working with podman
-      # - uses: uraimo/run-on-arch-action@v2
-      #   name: Build images arm64
-      #   id: build
-      #   with:
-      #     arch: aarch64
-      #     distro: ubuntu20.04
-      #     shell: /bin/bash
-      #     env: |
-      #       VERSION: "v0.0.0-devel-pr.${{ github.event.pull_request.number }}"
-      #       TOOLS_REPO: localhost/tools
-      #       PLUGIN_TESTS_REPO: localhost/plugin-openshift-tests
-      #       MGM_REPO: localhost/must-gather-monitoring
-      #     run: |
-      #       apt-get update \
-      #         && apt -y install build-essential lsb-release curl gpg
-      #       # https://podman.io/docs/installation
-      #       mkdir -p /etc/apt/keyrings
-      #       curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
-      #         | gpg --dearmor \
-      #         | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-      #       echo \
-      #         "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
-      #           https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
-      #         | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-      #       #apt-get update -qq
-      #       apt-get -qq -y install podman
-
-      #       echo "> Build and publish container image:"
-      #       make build-arch-arm64 VERSION=${VERSION}
-
-      # - name: Build manifests
-      #   shell: bash
-      #   run: |
-      #     echo "> Build and publish container image:"
-      #     make build-manifests VERSION=${VERSION}
-
-      # # https://github.com/marketplace/actions/podman-login
-      # - name: Log in to Quay.io
-      #   uses: redhat-actions/podman-login@v1
-      #   with:
-      #     username: ${{ env.PROD_QUAY_USER }}
-      #     password: ${{ env.PROD_QUAY_PASS }}
-      #     registry: quay.io
-
-      # - name: Push images
-      #   shell: bash
-      #   run: |
-      #     echo "> PuBuild and publish manifests"
-      #     make push-manifests VERSION=${VERSION}
-
-      # # Commenting in PR
-      # - name: Find comment
-      #   uses: peter-evans/find-comment@v2
-      #   id: fbc
-      #   with:
-      #     issue-number: ${{ github.event.pull_request.number }}
-      #     comment-author: 'github-actions[bot]'
-      #     body-includes: '<!-- id-build-comment -->'
-      # - name: Create comment
-      #   # if: steps.fbc.outputs.comment-id == ''
-      #   uses: peter-evans/create-or-update-comment@v3
-      #   with:
-      #     issue-number: ${{ github.event.pull_request.number }}
-      #     body: |
-      #       <!-- id-build-comment -->
-      #       Images built:
-      #       - Tools: [quay.io/opct/tools:${{ env.VERSION }}](https://quay.io/repository/opct/tools?tab=tags)
-      #       - Plugin openshift-tests: [quay.io/opct/plugin-openshift-tests:${{ env.VERSION }}](https://quay.io/repository/opct/plugin-openshift-tests?tab=tags)
-      #       - Must-Gather Monitoring: [quay.io/opct/must-gather-monitoring:${{ env.VERSION }}](https://quay.io/repository/opct/must-gather-monitoring?tab=tags)
-      #     reactions: rocket
-
-#
 # Releasing: triggered when a tag is created
 #
   release:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    needs:
-      - build-container
+    needs: [linters]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release-devel.yaml
+++ b/.github/workflows/release-devel.yaml
@@ -1,0 +1,132 @@
+---
+name: release-devel
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  linters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Shellcheck - hack
+        uses: azohra/shell-linter@latest
+        with:
+          path: "hack/*.sh"
+
+      - name: Shellcheck - Plugin - openshift-tests
+        uses: azohra/shell-linter@latest
+        with:
+          path: './openshift-tests-provider-cert/plugin/*.sh'
+
+      - name: Shellcheck - Plugin - openshift-tests - hack
+        uses: azohra/shell-linter@latest
+        with:
+          path: './openshift-tests-provider-cert/hack/*.sh'
+
+#
+# Build container image
+#
+  build-container:
+    name: release container(devel)
+    runs-on: ubuntu-22.04
+    needs: [linters]
+    env:
+      VERSION: "v0.0.0-devel-pr.${{ github.event.pull_request.number }}"
+      TOOLS_REPO: localhost/tools
+      PLUGIN_TESTS_REPO: localhost/plugin-openshift-tests
+      MGM_REPO: localhost/must-gather-monitoring
+
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Build images x86_64
+        shell: bash
+        run: |
+          echo "> Build and publish container image:"
+          make build-arch-amd64 VERSION=${VERSION}
+
+      # # TODO1: arm64 environment on Github Actions is not working.
+      # # manual steps is required:
+      # # $ make build-arch-arm64 VERSION=${VERSION}
+      # # $ make push-manifests VERSION=${VERSION}
+      #
+      # # TODO2: Quay login is not working for newer steps. Secrets are returning empty values.
+      #
+      # image is not working with podman
+      # - uses: uraimo/run-on-arch-action@v2
+      #   name: Build images arm64
+      #   id: build
+      #   with:
+      #     arch: aarch64
+      #     distro: ubuntu20.04
+      #     shell: /bin/bash
+      #     env: |
+      #       VERSION: "v0.0.0-devel-pr.${{ github.event.pull_request.number }}"
+      #       TOOLS_REPO: localhost/tools
+      #       PLUGIN_TESTS_REPO: localhost/plugin-openshift-tests
+      #       MGM_REPO: localhost/must-gather-monitoring
+      #     run: |
+      #       apt-get update \
+      #         && apt -y install build-essential lsb-release curl gpg
+      #       # https://podman.io/docs/installation
+      #       mkdir -p /etc/apt/keyrings
+      #       curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
+      #         | gpg --dearmor \
+      #         | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+      #       echo \
+      #         "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg]\
+      #           https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_$(lsb_release -rs)/ /" \
+      #         | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
+      #       #apt-get update -qq
+      #       apt-get -qq -y install podman
+
+      #       echo "> Build and publish container image:"
+      #       make build-arch-arm64 VERSION=${VERSION}
+
+      # - name: Build manifests
+      #   shell: bash
+      #   run: |
+      #     echo "> Build and publish container image:"
+      #     make build-manifests VERSION=${VERSION}
+
+      # # https://github.com/marketplace/actions/podman-login
+      # - name: Log in to Quay.io
+      #   uses: redhat-actions/podman-login@v1
+      #   with:
+      #     username: ${{ env.PROD_QUAY_USER }}
+      #     password: ${{ env.PROD_QUAY_PASS }}
+      #     registry: quay.io
+
+      # - name: Push images
+      #   shell: bash
+      #   run: |
+      #     echo "> PuBuild and publish manifests"
+      #     make push-manifests VERSION=${VERSION}
+
+      # # Commenting in PR
+      # - name: Find comment
+      #   uses: peter-evans/find-comment@v2
+      #   id: fbc
+      #   with:
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     comment-author: 'github-actions[bot]'
+      #     body-includes: '<!-- id-build-comment -->'
+      # - name: Create comment
+      #   # if: steps.fbc.outputs.comment-id == ''
+      #   uses: peter-evans/create-or-update-comment@v3
+      #   with:
+      #     issue-number: ${{ github.event.pull_request.number }}
+      #     body: |
+      #       <!-- id-build-comment -->
+      #       Images built:
+      #       - Tools: [quay.io/opct/tools:${{ env.VERSION }}](https://quay.io/repository/opct/tools?tab=tags)
+      #       - Plugin openshift-tests: [quay.io/opct/plugin-openshift-tests:${{ env.VERSION }}](https://quay.io/repository/opct/plugin-openshift-tests?tab=tags)
+      #       - Must-Gather Monitoring: [quay.io/opct/must-gather-monitoring:${{ env.VERSION }}](https://quay.io/repository/opct/must-gather-monitoring?tab=tags)
+      #     reactions: rocket


### PR DESCRIPTION
- Isolate tag release jobs to a dedicated workflow trigered by push on
  tags prefixed with 'v*'
- Isolate devel container image release added on https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/51