### PR TITLE
OPCT-257: fixes/ci pipeline to publish multi-arch manifests (#59)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Skip login step when the PR is from external repo, where
+      # Secrets isnt exported.
       - name: Login to Docker Hub
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -144,8 +147,8 @@ jobs:
     needs: [build-container-amd64]
     env:
       PLATFORMS: linux/amd64,linux/arm64
-      EXPIRATION: 1d
-      PUSH: false
+      EXPIRATION: never
+      PUSH: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
> This is a backport patching and fixing the release pipeline applied on branch `release-v0.5` (#59). It should be merged to `main` to feed the #57

CI pipeline is crashing when publishing a tag using an old build method.

This syncronizes to main the fixes applied in `release-0.5` branch (and tag [v0.5.0-alpha.4](https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/releases/tag/v0.5.0-alpha.4)):
- missing dependencies from #51 by calling the new multi-arch build scripts.
- unsupported step for docker login in Pull Requests from forks (external pushes)
- fix push expiration for PR builds on local branches.