### PR TITLE
OPCT-298: mmg: Fix URI encoder when creating query URL

### DIFF
--- a/must-gather-monitoring/Containerfile
+++ b/must-gather-monitoring/Containerfile
@@ -17,6 +17,7 @@ RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf \
     && microdnf clean all
 
 COPY --from=tools /usr/bin/oc /usr/bin/oc
+COPY --from=tools /usr/bin/jq /usr/bin/jq
 
 # Copy all collection scripts to /usr/bin
 COPY collection-scripts/* /usr/bin/
@@ -26,4 +27,4 @@ COPY runner_plugin /usr/bin/
 
 RUN chmod u+x /usr/bin/gather* /usr/bin/runner_plugin
 
-ENTRYPOINT ["/usr/bin/gather"]
+CMD ["/usr/bin/gather"]

--- a/must-gather-monitoring/collection-scripts/gather
+++ b/must-gather-monitoring/collection-scripts/gather
@@ -59,7 +59,7 @@ OPT_GATHER_QUERY_RANGE+=( [node-disk-saturation]='( instance_device:node_disk_io
 
 # Receive a valid string and return as URL Encoded
 function url_encode {
-    echo -n "$@" | curl -Gso /dev/null -w '%{url_effective}' --data-urlencode @- "" | cut -c 3-
+    printf %s "$@" | jq -sRr @uri
 }
 
 # Remove special chars from a string and return it
@@ -89,7 +89,6 @@ function prom_get_api {
 }
 
 function prom_get_expression_query {
-
     local api_expression="${1}"; shift
     local metric_name="${1}"; shift
     local query_param="${1}"; shift
@@ -140,11 +139,8 @@ function get_query {
 # Env var: GATHER_PROM_QUERIES_RANGE
 #
 function get_query_range {
-
     if [[ -f /must-gather/monitoring/env ]]; then
-        set -x
         echo "[get_query_range] Loading configuration /must-gather/monitoring/env"
-        set +x
     fi
     if [[ ${#OPT_GATHER_QUERY_RANGE[*]} -le 0 ]]; then
         echo_info "No queries was found to collect from env OPT_GATHER_QUERY_RANGE"
@@ -153,12 +149,11 @@ function get_query_range {
     mkdir -p "${MG_METRICS_PATH}"
 
     echo_info "Collecting queries range..."
-
     for name in ${!OPT_GATHER_QUERY_RANGE[*]}; do
+        echo "Scraping metric alias: ${name}"
         query=${OPT_GATHER_QUERY_RANGE[$name]}
         prom_get_expression_query "query_range" "${name}" "${query}" || true
     done
-    set +x
 }
 
 #


### PR DESCRIPTION
Problem: metrics is not correctly collected during artifacts collector with must-gather-metrics exporter.

Reason: URI is not correctly encoded when constructing the URL query to Prometheus, then the request is rejected by server.

Steps to reproduce:
- run standalone metrics collector: `oc adm must-gather --image=quay.io/opct/must-gather-monitoring:v0.5.0`
- check the errors in: `must-gather.local.*/*/monitoring/prometheus/metrics/*.stderr`
