### PR TITLE
OPCT-300: chaning Kube service URL

### DIFF
--- a/openshift-tests-plugin/pkg/plugin/plugin.go
+++ b/openshift-tests-plugin/pkg/plugin/plugin.go
@@ -51,7 +51,7 @@ const (
 	// WaitThresholdLimit defines the limit to wait for done file. Default 4h.
 	WaitThresholdLimit = 14400
 
-	KubeApiServerInternal = "https://172.30.0.1:443"
+	KubeApiServerInternal = "https://kubernetes.default.svc:443"
 	KubeApiServerSACertCA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	KubeApiServerSAToken  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -13,7 +13,7 @@ set -o errexit
 
 # shellcheck disable=SC2034
 declare -gr KUBECONFIG=/tmp/shared/kubeconfig;
-declare -gr KUBE_API_URL="https://172.30.0.1:443"
+declare -gr KUBE_API_URL="https://kubernetes.default.svc:443"
 declare -gr SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 declare -gr SA_CA_PATH="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 declare -gr CTRL_DONE_PLUGIN="/tmp/sonobuoy/results/done"


### PR DESCRIPTION
Following up changes:
https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/117
https://issues.redhat.com/browse/OPCT-300