### PR TITLE
OPCT-352: collect opct namespace data

### DIFF
--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -43,9 +43,10 @@ collect_must_gather() {
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Collecting must-gather"
     ${UTIL_OC_BIN} adm must-gather --dest-dir=${MUST_GATHER_DIR}
 
-    # TODO: Pre-process data from must-gather to avoid client-side extra steps.
-    # Examples of data to be processed:
-    # > insights rules
+    os_log_info "[executor][PluginID#${PLUGIN_ID}] Inspecting Namespace opct"
+    ${UTIL_OC_BIN} adm inspect namespace/opct --dest-dir=${MUST_GATHER_DIR}/inspect-opct
+
+    #> Pre-process data from must-gather to avoid client-side extra steps.
 
     # Clean sensitive data
     clean_must_gather
@@ -57,6 +58,10 @@ collect_must_gather() {
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Generating camgi report"
     camgi ${MUST_GATHER_DIR}/ > artifacts_must-gather_camgi.html || true
 
+    # TODO: Examples of additional data to be processed:
+    # > insights rules
+
+    #> Pack must-gather data
     # Create the tarball file artifacts_must-gather.tar.xz
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Packing must-gather"
     tar cfJ artifacts_must-gather.tar.xz ${MUST_GATHER_DIR}*


### PR DESCRIPTION
**What this PR does / why we need it**:

With the e2e controller, the logs is something nice to have to troubleshoot e2e failures. e2e logs will show if pods had been been mutated, helping the review phase.

Controller is added in PR https://github.com/redhat-openshift-ecosystem/opct/pull/160

**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/OPCT-352

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
