### PR TITLE
SPLAT-2132: introduce SHARED_DIR such that vSphere platform type can build creds

### DIFF
--- a/openshift-tests-plugin/plugin/platform.sh
+++ b/openshift-tests-plugin/plugin/platform.sh
@@ -12,6 +12,7 @@ declare -gx OPENSHIFT_TESTS_EXTRA_ARGS
 # shellcheck disable=SC2034
 declare -gr UTIL_OC_BIN=/usr/bin/oc
 declare -gr SERVICE_NAME="platform"
+declare -grx SHARED_DIR="/tmp/shared"
 
 
 os_log_info() {


### PR DESCRIPTION
**What this PR does / why we need it**:
`SHARED_DIR` is missing and result in platform vSphere failing to start

**Which issue(s) this PR fixes**:
Fixes SPLAT-2132

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [-] This change includes docs. 
- [-] This change includes unit tests.
