### PR TITLE
OCPBUGS-77783: use --file flag for kube-conformance test execution (#84)

### DIFF
--- a/openshift-tests-plugin/pkg/plugin/plugin.go
+++ b/openshift-tests-plugin/pkg/plugin/plugin.go
@@ -284,6 +284,24 @@ func (p *Plugin) Initialize() error {
 	}
 	log.Infof("Total test count: %d", len(p.SuiteTests))
 
+	// For kube-conformance plugin (10) on OCP 4.20+, use the extracted conformance
+	// test list to run only conformance tests via --file flag. On 4.20+ the suite
+	// kubernetes/conformance was removed from openshift-tests, requiring extraction
+	// from external binaries. The suite name must be cleared so openshift-tests runs
+	// only the tests in the file without a suite adding extra tests.
+	// On pre-4.20, DEFAULT_SUITE_NAME is "kubernetes/conformance" which works directly.
+	if p.id == PluginId10 {
+		suiteName := os.Getenv("DEFAULT_SUITE_NAME")
+		if suiteName != "" && suiteName != "kubernetes/conformance" {
+			k8sConformanceList := "/tmp/shared/k8s-conformance-tests.list"
+			if info, err := os.Stat(k8sConformanceList); err == nil && info.Size() > 0 {
+				log.Infof("Setting run file for plugin %s using extracted conformance list %s", p.name, k8sConformanceList)
+				p.OTRunner.File = k8sConformanceList
+				p.OTRunner.SuiteName = ""
+			}
+		}
+	}
+
 	if err := p.InitalizeDevelMode(); err != nil {
 		log.Errorf("error setting up devel mode: %v", err)
 	}

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -63,17 +63,16 @@ elif [[ "${PLUGIN_NAME:-}" == "openshift-cluster-upgrade" ]] && [[ "${RUN_MODE:-
         --dry-run -o ${CTRL_SUITE_LIST}
 
 elif [[ "${PLUGIN_NAME:-}" != "openshift-cluster-upgrade" ]]; then
-    # For 10-openshift-kube-conformance plugin, we want to check if we have extracted k8s conformance tests from OTE,
-    # so that we can workaround the 4.20+ issue that suite kubernetes/conformance was removed.
-    # Check if we have extracted k8s conformance tests from OTE for kubernetes/conformance suite.
-    # The test list extraction is done in the init container of the plugin. Check the plugin manifest for more details.
+    # For 10-openshift-kube-conformance plugin, check if the init container extracted
+    # the conformance test list. If so, use it as the suite list for both progress
+    # tracking and test execution (via -f flag).
     K8S_CONFORMANCE_LIST="/tmp/shared/k8s-conformance-tests.list"
     if [[ "${PLUGIN_NAME:-}" == "openshift-kube-conformance" ]] && [[ -f "${K8S_CONFORMANCE_LIST}" ]]; then
         TEST_COUNT=$(wc -l < "${K8S_CONFORMANCE_LIST}")
         if [[ $TEST_COUNT -gt 0 ]]; then
-            echo "Using extracted Kubernetes conformance tests from OTE (${TEST_COUNT} tests)"
+            echo "Using extracted Kubernetes conformance tests (${TEST_COUNT} tests)"
             cp "${K8S_CONFORMANCE_LIST}" "${CTRL_SUITE_LIST}"
-            echo "Tests extracted from k8s-tests-ext binary" > ${CTRL_SUITE_LIST}.log
+            echo "Tests extracted from openshift-tests binary" > ${CTRL_SUITE_LIST}.log
         else
             echo "Warning: Extracted test list is empty, falling back to default suite"
             # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary

Use `--file` flag for kube-conformance test execution to ensure only conformance-tagged tests are run on OCP 4.20+.

## Problem

Even when the init container successfully extracts the conformance test list (433 tests), the plugin container creates the start script without `--file` flag. The tests container runs the full
`kubernetes/conformance/parallel` suite (~2968 tests) instead of the extracted conformance-only list.

Additionally, using `--file` WITH a suite name does not work — `openshift-tests` loads additional tests from external binaries in serial phases, growing the count from 433 back to 2968.

## Solution

When the extracted conformance list exists
(`/tmp/shared/k8s-conformance-tests.list`), the plugin now:
1. Sets `OTRunner.File` to the extracted list (adds `--file` flag)
2. Clears `OTRunner.SuiteName` (removes suite name from command)

This changes the start script from:
```
openshift-tests run kubernetes/conformance/parallel ...    -> 2968 tests
```
To:
```
openshift-tests run --file=/tmp/shared/k8s-conformance-tests.list ...    -> 433 tests
```

## Test Results

Tested on OCP 4.20.19:
- Before fix: count grows from 433 to 2968 (suite adds extra tests)
- After fix: count stays at 433 throughout execution

## Related

- Bug: [OCPBUGS-77783](https://redhat.atlassian.net/browse/OCPBUGS-77783)
- Companion PR (opct): https://github.com/redhat-openshift-ecosystem/opct/pull/205

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above.
  GitHub automatically recognizes the commit description (-m"Why") in single commit PRs and
  adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line
  for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required`
  (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485
  as an example.
- See https://github.com/redhat-openshift-ecosystem/opct/blob/main/CONTRIBUTING.md for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
