### PR TITLE
OCPBUGS-77783: fix kube-conformance suite name and init error propagation

### DIFF
--- a/openshift-tests-plugin/pkg/plugin/plugin.go
+++ b/openshift-tests-plugin/pkg/plugin/plugin.go
@@ -287,8 +287,9 @@ func (p *Plugin) Initialize() error {
 	// For kube-conformance plugin (10) on OCP 4.20+, use the extracted conformance
 	// test list to run only conformance tests via --file flag. On 4.20+ the suite
 	// kubernetes/conformance was removed from openshift-tests, requiring extraction
-	// from external binaries. The suite name must be cleared so openshift-tests runs
-	// only the tests in the file without a suite adding extra tests.
+	// On 4.20+, conformance tests are extracted from k8s-tests-ext and run via --file.
+	// The suite name is preserved from DEFAULT_SUITE_NAME (kubernetes/conformance/parallel)
+	// so openshift-tests filters tests consistently with the suite definition.
 	// On pre-4.20, DEFAULT_SUITE_NAME is "kubernetes/conformance" which works directly.
 	if p.id == PluginId10 {
 		suiteName := os.Getenv("DEFAULT_SUITE_NAME")
@@ -297,7 +298,7 @@ func (p *Plugin) Initialize() error {
 			if info, err := os.Stat(k8sConformanceList); err == nil && info.Size() > 0 {
 				log.Infof("Setting run file for plugin %s using extracted conformance list %s", p.name, k8sConformanceList)
 				p.OTRunner.File = k8sConformanceList
-				p.OTRunner.SuiteName = "all"
+				p.OTRunner.SuiteName = suiteName
 			}
 		}
 	}

--- a/openshift-tests-plugin/pkg/plugin/plugin.go
+++ b/openshift-tests-plugin/pkg/plugin/plugin.go
@@ -297,7 +297,7 @@ func (p *Plugin) Initialize() error {
 			if info, err := os.Stat(k8sConformanceList); err == nil && info.Size() > 0 {
 				log.Infof("Setting run file for plugin %s using extracted conformance list %s", p.name, k8sConformanceList)
 				p.OTRunner.File = k8sConformanceList
-				p.OTRunner.SuiteName = ""
+				p.OTRunner.SuiteName = "all"
 			}
 		}
 	}

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -63,6 +63,41 @@ elif [[ "${PLUGIN_NAME:-}" == "openshift-cluster-upgrade" ]] && [[ "${RUN_MODE:-
         --dry-run -o ${CTRL_SUITE_LIST}
 
 elif [[ "${PLUGIN_NAME:-}" != "openshift-cluster-upgrade" ]]; then
+    # Check if the init container reported an error
+    INIT_ERROR_FILE="/tmp/shared/init-error.log"
+    if [[ "${PLUGIN_NAME:-}" == "openshift-kube-conformance" ]] && [[ -f "${INIT_ERROR_FILE}" ]]; then
+        INIT_ERR=$(cat "${INIT_ERROR_FILE}")
+        echo "ERROR: Init container failed to extract conformance tests:"
+        echo "${INIT_ERR}"
+        # Write error as suite list entry so plugin reports it
+        echo "\"[opct] init-error: ${INIT_ERR}\"" > ${CTRL_SUITE_LIST}
+        touch ${CTRL_SUITE_LIST}.done
+        # Create a JUnit XML so the plugin can process results without crashing
+        mkdir -p /tmp/shared/junit
+        cat > /tmp/shared/junit/junit_e2e_init-error.xml <<JUNITEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="openshift-kube-conformance" tests="1" failures="1" errors="0" time="0">
+  <testcase name="[opct] kube-conformance init container" time="0">
+    <failure message="Init container failed to extract conformance tests">${INIT_ERR}</failure>
+  </testcase>
+</testsuite>
+JUNITEOF
+        # Wait for FIFO to be created by plugin, then write failed result
+        for i in $(seq 1 30); do
+            if [[ -p /tmp/shared/fifo ]]; then
+                echo "failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR}\"" > /tmp/shared/fifo
+                break
+            fi
+            sleep 1
+        done
+        touch ${CTRL_DONE_TESTS}
+        # Wait for plugin done
+        while true; do
+            if [[ -f ${CTRL_DONE_PLUGIN} ]]; then exit 0; fi
+            sleep 10
+        done
+    fi
+
     # For 10-openshift-kube-conformance plugin, check if the init container extracted
     # the conformance test list. If so, use it as the suite list for both progress
     # tracking and test execution (via -f flag).

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -86,7 +86,12 @@ JUNITEOF
         for attempt in $(seq 1 30); do
             if [[ -p /tmp/shared/fifo ]]; then
                 echo "FIFO ready (attempt ${attempt}), writing error result..."
-                echo "failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR}\"" > /tmp/shared/fifo
+                fifo_msg="failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR}\""
+                if timeout 5s bash -c 'printf "%s\n" "$1" > /tmp/shared/fifo' _ "${fifo_msg}"; then
+                    echo "FIFO write completed."
+                else
+                    echo "Warning: timed out writing init error to FIFO; continuing with JUnit-only failure reporting."
+                fi
                 break
             fi
             sleep 1

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -66,13 +66,15 @@ elif [[ "${PLUGIN_NAME:-}" != "openshift-cluster-upgrade" ]]; then
     # Check if the init container reported an error
     INIT_ERROR_FILE="/tmp/shared/init-error.log"
     if [[ "${PLUGIN_NAME:-}" == "openshift-kube-conformance" ]] && [[ -f "${INIT_ERROR_FILE}" ]]; then
-        INIT_ERR=$(cat "${INIT_ERROR_FILE}")
+        INIT_ERR=$(<"${INIT_ERROR_FILE}")
+        # Normalize to single line for suite list and FIFO consumers
+        INIT_ERR_LINE=${INIT_ERR//$'\n'/ }
         echo "ERROR: Init container failed to extract conformance tests:"
         echo "${INIT_ERR}"
         # Escape XML special characters in error message
         INIT_ERR_XML=$(echo "${INIT_ERR}" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')
         # Write error as suite list entry so plugin reports it
-        echo "\"[opct] init-error: ${INIT_ERR}\"" > ${CTRL_SUITE_LIST}
+        printf '"[opct] init-error: %s"\n' "${INIT_ERR_LINE}" > "${CTRL_SUITE_LIST}"
         touch ${CTRL_SUITE_LIST}.done
         # Create a JUnit XML so the plugin can process results without crashing
         mkdir -p /tmp/shared/junit
@@ -88,7 +90,7 @@ JUNITEOF
         for attempt in $(seq 1 30); do
             if [[ -p /tmp/shared/fifo ]]; then
                 echo "FIFO ready (attempt ${attempt}), writing error result..."
-                fifo_msg="failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR}\""
+                fifo_msg="failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR_LINE}\""
                 echo "${fifo_msg}" > /tmp/shared/fifo-msg.txt
                 if timeout 5s sh -c "cat /tmp/shared/fifo-msg.txt > /tmp/shared/fifo"; then
                     echo "FIFO write completed."

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -69,6 +69,8 @@ elif [[ "${PLUGIN_NAME:-}" != "openshift-cluster-upgrade" ]]; then
         INIT_ERR=$(cat "${INIT_ERROR_FILE}")
         echo "ERROR: Init container failed to extract conformance tests:"
         echo "${INIT_ERR}"
+        # Escape XML special characters in error message
+        INIT_ERR_XML=$(echo "${INIT_ERR}" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')
         # Write error as suite list entry so plugin reports it
         echo "\"[opct] init-error: ${INIT_ERR}\"" > ${CTRL_SUITE_LIST}
         touch ${CTRL_SUITE_LIST}.done
@@ -78,7 +80,7 @@ elif [[ "${PLUGIN_NAME:-}" != "openshift-cluster-upgrade" ]]; then
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="openshift-kube-conformance" tests="1" failures="1" errors="0" time="0">
   <testcase name="[opct] kube-conformance init container" time="0">
-    <failure message="Init container failed to extract conformance tests">${INIT_ERR}</failure>
+    <failure message="Init container failed to extract conformance tests">${INIT_ERR_XML}</failure>
   </testcase>
 </testsuite>
 JUNITEOF

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -83,8 +83,9 @@ elif [[ "${PLUGIN_NAME:-}" != "openshift-cluster-upgrade" ]]; then
 </testsuite>
 JUNITEOF
         # Wait for FIFO to be created by plugin, then write failed result
-        for _i in $(seq 1 30); do
+        for attempt in $(seq 1 30); do
             if [[ -p /tmp/shared/fifo ]]; then
+                echo "FIFO ready (attempt ${attempt}), writing error result..."
                 echo "failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR}\"" > /tmp/shared/fifo
                 break
             fi

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -89,7 +89,8 @@ JUNITEOF
             if [[ -p /tmp/shared/fifo ]]; then
                 echo "FIFO ready (attempt ${attempt}), writing error result..."
                 fifo_msg="failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR}\""
-                if timeout 5s bash -c 'printf "%s\n" "$1" > /tmp/shared/fifo' _ "${fifo_msg}"; then
+                echo "${fifo_msg}" > /tmp/shared/fifo-msg.txt
+                if timeout 5s sh -c "cat /tmp/shared/fifo-msg.txt > /tmp/shared/fifo"; then
                     echo "FIFO write completed."
                 else
                     echo "Warning: timed out writing init error to FIFO; continuing with JUnit-only failure reporting."

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -83,7 +83,7 @@ elif [[ "${PLUGIN_NAME:-}" != "openshift-cluster-upgrade" ]]; then
 </testsuite>
 JUNITEOF
         # Wait for FIFO to be created by plugin, then write failed result
-        for i in $(seq 1 30); do
+        for _i in $(seq 1 30); do
             if [[ -p /tmp/shared/fifo ]]; then
                 echo "failed: (0s) $(date -u +%Y-%m-%dT%H:%M:%S) \"[opct] kube-conformance init container error: ${INIT_ERR}\"" > /tmp/shared/fifo
                 break

--- a/openshift-tests-plugin/plugin/entrypoint-tests.sh
+++ b/openshift-tests-plugin/plugin/entrypoint-tests.sh
@@ -92,11 +92,22 @@ JUNITEOF
             sleep 1
         done
         touch ${CTRL_DONE_TESTS}
-        # Wait for plugin done
-        while true; do
-            if [[ -f ${CTRL_DONE_PLUGIN} ]]; then exit 0; fi
+        # Wait for plugin done with timeout (max 30 minutes)
+        max_wait=180
+        wait_count=0
+        while [[ ${wait_count} -lt ${max_wait} ]]; do
+            if [[ -f ${CTRL_DONE_PLUGIN} ]]; then
+                echo "Plugin done detected, exiting."
+                exit 0
+            fi
+            wait_count=$((wait_count + 1))
+            if (( wait_count % 6 == 0 )); then
+                echo "Waiting for plugin done [${CTRL_DONE_PLUGIN}] (${wait_count}/${max_wait})..."
+            fi
             sleep 10
         done
+        echo "Timeout waiting for plugin done after $((max_wait * 10))s, exiting."
+        exit 1
     fi
 
     # For 10-openshift-kube-conformance plugin, check if the init container extracted


### PR DESCRIPTION
## Summary

Follow-up to #84. Fixes kube-conformance test execution on OCP 4.20+ and adds init container error propagation.

## Changes

### 1. Fix SuiteName for file-based execution (`plugin.go`)
Set `SuiteName = "all"` instead of `""` when using `--file` with extracted conformance tests. This generates `openshift-tests run all --file=<list>` which correctly intersects the file list with all available tests.

### 2. Init container error propagation (`entrypoint-tests.sh`)
When the init container fails to extract conformance tests (e.g., auth failure, missing binary), the entrypoint now:
- Detects the error file (`/tmp/shared/init-error.log`) written by the init container
- Creates a JUnit XML (`junit_e2e_init-error.xml`) with the failure details
- Sends a failed test result via FIFO to the plugin
- Completes gracefully so the pipeline chain is not blocked
- Waits for plugin done with a 30-minute timeout

This ensures the error is captured in the results tarball and visible in `opct status`/`report`, rather than silently falling back to an incorrect test suite.

## Test Results

**Happy path** (stable 4.20.19 Platform External):
- Init container extracted 414 conformance tests via internal registry
- `openshift-tests run all --file=<414 tests>` → 414/414 passed
- `opct status`: `10-openshift-kube-conformance | complete | 414/414 (0 failures)`

**Error path** (nightly 4.20, init container auth failure):
- Init error propagated via JUnit → plugin completed with `1/1 failed`
- Chain not blocked → all other plugins ran normally
- Error visible in `opct status` (failed) and results tarball

## Related

- Bug: [OCPBUGS-77783](https://redhat.atlassian.net/browse/OCPBUGS-77783)
- Previous PR: #84 (merged, version check logic retained)
- Companion PR (opct): https://github.com/redhat-openshift-ecosystem/opct/pull/205