### PR TITLE
OPCT-428: add must-gather-clean to artifacts-collector for sensitive data cleaning

### DIFF
--- a/artifacts-collector/Containerfile
+++ b/artifacts-collector/Containerfile
@@ -9,11 +9,12 @@ FROM quay.io/opct/tools:v0.5.0 AS tools
 
 FROM quay.io/fedora/fedora-minimal:41 AS mgc
 ARG MGC_VERSION=0.0.5
+ARG TARGETARCH=amd64
 RUN microdnf install -y tar gzip curl && \
     set -euo pipefail && \
-    curl -sSLf -o /tmp/mgc.tar.gz https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/must-gather-clean-linux-amd64.tar.gz && \
+    curl -sSLf -o /tmp/mgc.tar.gz https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/must-gather-clean-linux-${TARGETARCH}.tar.gz && \
     curl -sSLf -o /tmp/mgc.sha256 https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/SHA256_SUM && \
-    echo "$(grep must-gather-clean-linux-amd64.tar.gz /tmp/mgc.sha256 | awk '{print $1}')  /tmp/mgc.tar.gz" | sha256sum --check --strict - && \
+    echo "$(grep must-gather-clean-linux-${TARGETARCH}.tar.gz /tmp/mgc.sha256 | awk '{print $1}')  /tmp/mgc.tar.gz" | sha256sum --check --strict - && \
     tar xz -C /usr/local/bin -f /tmp/mgc.tar.gz must-gather-clean
 
 # Main image

--- a/artifacts-collector/Containerfile
+++ b/artifacts-collector/Containerfile
@@ -9,7 +9,8 @@ FROM quay.io/opct/tools:v0.5.0 AS tools
 
 FROM quay.io/fedora/fedora-minimal:41 AS mgc
 ARG MGC_VERSION=0.0.5
-RUN set -euo pipefail && \
+RUN microdnf install -y tar gzip curl && \
+    set -euo pipefail && \
     curl -sSLf -o /tmp/mgc.tar.gz https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/must-gather-clean-linux-amd64.tar.gz && \
     curl -sSLf -o /tmp/mgc.sha256 https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/SHA256_SUM && \
     echo "$(grep must-gather-clean-linux-amd64.tar.gz /tmp/mgc.sha256 | awk '{print $1}')  /tmp/mgc.tar.gz" | sha256sum --check --strict - && \

--- a/artifacts-collector/Containerfile
+++ b/artifacts-collector/Containerfile
@@ -7,6 +7,11 @@ FROM ${PLUGIN_REPO}:${BUILD_VERSION} AS plugin
 
 FROM quay.io/opct/tools:v0.5.0 AS tools
 
+FROM quay.io/fedora/fedora-minimal:41 AS mgc
+ARG MGC_VERSION=0.0.5
+RUN curl -sL https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/must-gather-clean-linux-amd64.tar.gz \
+    | tar xz -C /usr/local/bin must-gather-clean
+
 # Main image
 FROM quay.io/fedora/fedora-minimal:41
 ARG QUAY_EXPIRATION=never
@@ -25,12 +30,15 @@ RUN echo "fastestmirror=true" >> /etc/dnf/dnf.conf \
 COPY --from=tools /usr/bin/oc /usr/bin/oc
 COPY --from=tools /usr/bin/jq /usr/bin/jq
 COPY --from=tools /usr/bin/camgi /usr/bin/camgi
+COPY --from=mgc /usr/local/bin/must-gather-clean /usr/bin/must-gather-clean
 
 # plugin openshift-tests must be built first (dependency)
 COPY --from=plugin /usr/bin/openshift-tests-plugin /usr/bin/openshift-tests-plugin
 
 COPY ./*.sh ./
 COPY ./collector.sh ./
+COPY ./mgc-config-mustgather.yaml /plugin/
+COPY ./mgc-config-e2e.yaml /plugin/
 
 RUN ln -svf /usr/bin/oc /usr/bin/kubectl
 

--- a/artifacts-collector/Containerfile
+++ b/artifacts-collector/Containerfile
@@ -9,8 +9,11 @@ FROM quay.io/opct/tools:v0.5.0 AS tools
 
 FROM quay.io/fedora/fedora-minimal:41 AS mgc
 ARG MGC_VERSION=0.0.5
-RUN curl -sL https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/must-gather-clean-linux-amd64.tar.gz \
-    | tar xz -C /usr/local/bin must-gather-clean
+RUN set -euo pipefail && \
+    curl -sSLf -o /tmp/mgc.tar.gz https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/must-gather-clean-linux-amd64.tar.gz && \
+    curl -sSLf -o /tmp/mgc.sha256 https://github.com/openshift/must-gather-clean/releases/download/v${MGC_VERSION}/SHA256_SUM && \
+    echo "$(grep must-gather-clean-linux-amd64.tar.gz /tmp/mgc.sha256 | awk '{print $1}')  /tmp/mgc.tar.gz" | sha256sum --check --strict - && \
+    tar xz -C /usr/local/bin -f /tmp/mgc.tar.gz must-gather-clean
 
 # Main image
 FROM quay.io/fedora/fedora-minimal:41

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -191,14 +191,23 @@ collect_metrics() {
     local metrics_src_dir
     metrics_src_dir=$(ls -d must-gather-metrics/*/ | head -1)
     local metrics_clean_dir="${metrics_src_dir%/}-clean"
-    must-gather-clean -c /plugin/mgc-config-mustgather.yaml \
+    if must-gather-clean -c /plugin/mgc-config-mustgather.yaml \
         -i "${metrics_src_dir}" -o "${metrics_clean_dir}" \
-        -v4 >./artifacts_log-mgc-must-gather-metrics.log 2>&1 && {
+        -v4 >./artifacts_log-mgc-must-gather-metrics.log 2>&1; then
         cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html "${metrics_clean_dir}/monitoring/" || true
-        mv "${metrics_src_dir}" "${metrics_src_dir%/}-orig"
-        mv "${metrics_clean_dir}" "${metrics_src_dir}"
-        rm -rf "${metrics_src_dir%/}-orig"
-    }
+        if mv "${metrics_src_dir}" "${metrics_src_dir%/}-orig" && \
+           mv "${metrics_clean_dir}" "${metrics_src_dir}"; then
+            rm -rf "${metrics_src_dir%/}-orig"
+        else
+            os_log_info "${msg_prefix} WARNING: swap failed, restoring original"
+            [ -d "${metrics_src_dir%/}-orig" ] && mv "${metrics_src_dir%/}-orig" "${metrics_src_dir}"
+            rm -rf "${metrics_clean_dir}"
+        fi
+    else
+        os_log_info "${msg_prefix} WARNING: must-gather-clean failed for metrics, skipping metrics packing"
+        rm -rf "${metrics_clean_dir}"
+        return
+    fi
 
     os_log_info "${msg_prefix} Packing must-gather-metrics..."
     cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html must-gather-metrics/*/monitoring/ || true

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -37,7 +37,8 @@ clean_must_gather() {
     local mg_clean_dir="${MUST_GATHER_DIR}-clean"
     must-gather-clean -c /plugin/mgc-config-mustgather.yaml \
         -i "${MUST_GATHER_DIR}" \
-        -o "${mg_clean_dir}" || {
+        -o "${mg_clean_dir}" \
+        -v4 >./artifacts_log-mgc-must-gather.log 2>&1 || {
         os_log_info "[executor][PluginID#${PLUGIN_ID}] must-gather-clean failed, falling back to sed"
         sed -i 's/\(internalRegistryPullSecret:\s*\).*/\1"<sensitive>"/' \
             ${MUST_GATHER_DIR}/*/cluster-scoped-resources/machineconfiguration.openshift.io/controllerconfigs/machine-config-controller.yaml >/dev/null 2>&1
@@ -59,7 +60,8 @@ clean_e2e_metadata() {
         local tmparchive="${archive}.tmp"
         tar xzf "${archive}" -C "${tmpdir}" || { rm -rf "${tmpdir}"; continue; }
         must-gather-clean -c /plugin/mgc-config-e2e.yaml \
-            -i "${tmpdir}" -o "${cleandir}" || { rm -rf "${tmpdir}" "${cleandir}"; continue; }
+            -i "${tmpdir}" -o "${cleandir}" \
+            -v4 >>./artifacts_log-mgc-e2e-metadata.log 2>&1 || { rm -rf "${tmpdir}" "${cleandir}"; continue; }
         tar czf "${tmparchive}" -C "${cleandir}" . && mv "${tmparchive}" "${archive}" || rm -f "${tmparchive}"
         rm -rf "${tmpdir}" "${cleandir}"
     done
@@ -185,8 +187,21 @@ collect_metrics() {
         return
     }
 
+    os_log_info "${msg_prefix} Cleaning must-gather-metrics with must-gather-clean"
+    local metrics_src_dir
+    metrics_src_dir=$(ls -d must-gather-metrics/*/ | head -1)
+    local metrics_clean_dir="${metrics_src_dir%/}-clean"
+    must-gather-clean -c /plugin/mgc-config-mustgather.yaml \
+        -i "${metrics_src_dir}" -o "${metrics_clean_dir}" \
+        -v4 >./artifacts_log-mgc-must-gather-metrics.log 2>&1 && {
+        cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html "${metrics_clean_dir}/monitoring/" 2>/dev/null || true
+        mv "${metrics_src_dir}" "${metrics_src_dir%/}-orig"
+        mv "${metrics_clean_dir}" "${metrics_src_dir}"
+        rm -rf "${metrics_src_dir%/}-orig"
+    }
+
     os_log_info "${msg_prefix} Packing must-gather-metrics..."
-    cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html must-gather-metrics/*/monitoring/
+    cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html must-gather-metrics/*/monitoring/ 2>/dev/null || true
     tar cfJ artifacts_must-gather-metrics.tar.xz -C must-gather-metrics/*/ monitoring/
 
     os_log_info "${msg_prefix} finished!"

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -33,9 +33,34 @@ send_test_progress() {
 # the steps here must ensure edge scenariois not added
 # in must-gather workflow.
 clean_must_gather() {
-    # clean registry credentials
-    sed -i 's/\(internalRegistryPullSecret:\s*\).*/\1"<sensitive>"/' \
-        ${MUST_GATHER_DIR}/*/cluster-scoped-resources/machineconfiguration.openshift.io/controllerconfigs/machine-config-controller.yaml >/dev/null
+    os_log_info "[executor][PluginID#${PLUGIN_ID}] Cleaning must-gather with must-gather-clean"
+    local mg_clean_dir="${MUST_GATHER_DIR}-clean"
+    must-gather-clean -c /plugin/mgc-config-mustgather.yaml \
+        -i "${MUST_GATHER_DIR}" \
+        -o "${mg_clean_dir}" || {
+        os_log_info "[executor][PluginID#${PLUGIN_ID}] must-gather-clean failed, falling back to sed"
+        sed -i 's/\(internalRegistryPullSecret:\s*\).*/\1"<sensitive>"/' \
+            ${MUST_GATHER_DIR}/*/cluster-scoped-resources/machineconfiguration.openshift.io/controllerconfigs/machine-config-controller.yaml >/dev/null 2>&1
+        return
+    }
+    rm -rf "${MUST_GATHER_DIR}"
+    mv "${mg_clean_dir}" "${MUST_GATHER_DIR}"
+}
+
+clean_e2e_metadata() {
+    os_log_info "[executor][PluginID#${PLUGIN_ID}] Cleaning e2e metadata archives"
+    for archive in "${RESULTS_DIR}"/artifacts_e2e-metadata-*.tar.gz; do
+        [ -f "${archive}" ] || continue
+        os_log_info "[executor][PluginID#${PLUGIN_ID}] Cleaning ${archive##*/}"
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        local cleandir="${tmpdir}-clean"
+        tar xzf "${archive}" -C "${tmpdir}" || { rm -rf "${tmpdir}"; continue; }
+        must-gather-clean -c /plugin/mgc-config-e2e.yaml \
+            -i "${tmpdir}" -o "${cleandir}" || { rm -rf "${tmpdir}" "${cleandir}"; continue; }
+        tar czf "${archive}" -C "${cleandir}" .
+        rm -rf "${tmpdir}" "${cleandir}"
+    done
 }
 
 # Collect must-gather and pre-process any data* from it, then create a tarball file.
@@ -263,6 +288,10 @@ run_plugin_collector() {
         send_test_progress "status=running=kube-burner";
         collect_kube_burner || true
     fi
+
+    # Clean sensitive data from e2e metadata archives
+    send_test_progress "status=running=cleaning sensitive data";
+    clean_e2e_metadata || true
 
     # Create result file used to publish to sonobuoy aggregator. (must be the last step)
     send_test_progress "status=running=saving artifacts";

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -201,7 +201,7 @@ collect_metrics() {
            mv "${metrics_clean_dir}" "${metrics_src_dir}"; then
             rm -rf "${metrics_src_dir%/}-orig"
         else
-            os_log_info "${msg_prefix} WARNING: swap failed, restoring original"
+            os_log_info "${msg_prefix} WARNING: moving files failed, restoring original"
             [ -d "${metrics_src_dir%/}-orig" ] && mv "${metrics_src_dir%/}-orig" "${metrics_src_dir}"
             rm -rf "${metrics_clean_dir}"
         fi

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -194,14 +194,14 @@ collect_metrics() {
     must-gather-clean -c /plugin/mgc-config-mustgather.yaml \
         -i "${metrics_src_dir}" -o "${metrics_clean_dir}" \
         -v4 >./artifacts_log-mgc-must-gather-metrics.log 2>&1 && {
-        cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html "${metrics_clean_dir}/monitoring/" 2>/dev/null || true
+        cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html "${metrics_clean_dir}/monitoring/" || true
         mv "${metrics_src_dir}" "${metrics_src_dir%/}-orig"
         mv "${metrics_clean_dir}" "${metrics_src_dir}"
         rm -rf "${metrics_src_dir%/}-orig"
     }
 
     os_log_info "${msg_prefix} Packing must-gather-metrics..."
-    cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html must-gather-metrics/*/monitoring/ 2>/dev/null || true
+    cp -v must-gather-metrics/timestamp must-gather-metrics/event-filter.html must-gather-metrics/*/monitoring/ || true
     tar cfJ artifacts_must-gather-metrics.tar.xz -C must-gather-metrics/*/ monitoring/
 
     os_log_info "${msg_prefix} finished!"

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -33,15 +33,17 @@ send_test_progress() {
 # the steps here must ensure edge scenariois not added
 # in must-gather workflow.
 clean_must_gather() {
+    # always clean internalRegistryPullSecret first (safety net before MGC)
+    sed -i 's/\(internalRegistryPullSecret:\s*\).*/\1"<sensitive>"/' \
+        ${MUST_GATHER_DIR}/*/cluster-scoped-resources/machineconfiguration.openshift.io/controllerconfigs/machine-config-controller.yaml >/dev/null 2>&1
+
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Cleaning must-gather with must-gather-clean"
     local mg_clean_dir="${MUST_GATHER_DIR}-clean"
     must-gather-clean -c /plugin/mgc-config-mustgather.yaml \
         -i "${MUST_GATHER_DIR}" \
         -o "${mg_clean_dir}" \
         -v4 >./artifacts_log-mgc-must-gather.log 2>&1 || {
-        os_log_info "[executor][PluginID#${PLUGIN_ID}] must-gather-clean failed, falling back to sed"
-        sed -i 's/\(internalRegistryPullSecret:\s*\).*/\1"<sensitive>"/' \
-            ${MUST_GATHER_DIR}/*/cluster-scoped-resources/machineconfiguration.openshift.io/controllerconfigs/machine-config-controller.yaml >/dev/null 2>&1
+        os_log_info "[executor][PluginID#${PLUGIN_ID}] must-gather-clean failed, sed already applied"
         return
     }
     mv "${MUST_GATHER_DIR}" "${MUST_GATHER_DIR}-orig" && \

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -43,8 +43,9 @@ clean_must_gather() {
             ${MUST_GATHER_DIR}/*/cluster-scoped-resources/machineconfiguration.openshift.io/controllerconfigs/machine-config-controller.yaml >/dev/null 2>&1
         return
     }
-    rm -rf "${MUST_GATHER_DIR}"
-    mv "${mg_clean_dir}" "${MUST_GATHER_DIR}"
+    mv "${MUST_GATHER_DIR}" "${MUST_GATHER_DIR}-orig" && \
+        mv "${mg_clean_dir}" "${MUST_GATHER_DIR}" && \
+        rm -rf "${MUST_GATHER_DIR}-orig"
 }
 
 clean_e2e_metadata() {
@@ -55,10 +56,11 @@ clean_e2e_metadata() {
         local tmpdir
         tmpdir=$(mktemp -d)
         local cleandir="${tmpdir}-clean"
+        local tmparchive="${archive}.tmp"
         tar xzf "${archive}" -C "${tmpdir}" || { rm -rf "${tmpdir}"; continue; }
         must-gather-clean -c /plugin/mgc-config-e2e.yaml \
             -i "${tmpdir}" -o "${cleandir}" || { rm -rf "${tmpdir}" "${cleandir}"; continue; }
-        tar czf "${archive}" -C "${cleandir}" .
+        tar czf "${tmparchive}" -C "${cleandir}" . && mv "${tmparchive}" "${archive}" || rm -f "${tmparchive}"
         rm -rf "${tmpdir}" "${cleandir}"
     done
 }

--- a/artifacts-collector/mgc-config-e2e.yaml
+++ b/artifacts-collector/mgc-config-e2e.yaml
@@ -1,0 +1,8 @@
+config:
+  obfuscate:
+    - type: Regex
+      target: FileContents
+      regex: "sha256~[A-Za-z0-9_-]+"
+    - type: Regex
+      target: FileContents
+      regex: "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+"

--- a/artifacts-collector/mgc-config-e2e.yaml
+++ b/artifacts-collector/mgc-config-e2e.yaml
@@ -8,4 +8,4 @@ config:
       regex: "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+"
     - type: Regex
       target: FileContents
-      regex: "Authorization:\\s+\\w+\\s+[A-Za-z0-9+/=_-]{20,}"
+      regex: "(?i)Authorization:\\s+\\w+\\s+[A-Za-z0-9+/=_-]{20,}"

--- a/artifacts-collector/mgc-config-e2e.yaml
+++ b/artifacts-collector/mgc-config-e2e.yaml
@@ -6,3 +6,6 @@ config:
     - type: Regex
       target: FileContents
       regex: "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+"
+    - type: Regex
+      target: FileContents
+      regex: "Authorization:\\s+\\w+\\s+[A-Za-z0-9+/=_-]{20,}"

--- a/artifacts-collector/mgc-config-mustgather.yaml
+++ b/artifacts-collector/mgc-config-mustgather.yaml
@@ -8,7 +8,7 @@ config:
       regex: "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+"
     - type: Regex
       target: FileContents
-      regex: "Authorization:\\s+\\w+\\s+[A-Za-z0-9+/=_-]{20,}"
+      regex: "(?i)Authorization:\\s+\\w+\\s+[A-Za-z0-9+/=_-]{20,}"
     - type: Regex
       target: FileContents
       regex: "(?i)(secret|httpSecret):\\s+[A-Za-z0-9+/=_-]{20,}"

--- a/artifacts-collector/mgc-config-mustgather.yaml
+++ b/artifacts-collector/mgc-config-mustgather.yaml
@@ -15,9 +15,6 @@ config:
   omit:
     - type: Kubernetes
       kubernetesResource:
-        kind: "Secret"
-    - type: Kubernetes
-      kubernetesResource:
         kind: MachineConfig
         apiVersion: machineconfiguration.openshift.io/v1
     - type: Kubernetes

--- a/artifacts-collector/mgc-config-mustgather.yaml
+++ b/artifacts-collector/mgc-config-mustgather.yaml
@@ -1,0 +1,16 @@
+config:
+  obfuscate:
+    - type: Regex
+      target: FileContents
+      regex: "sha256~[A-Za-z0-9_-]+"
+    - type: Regex
+      target: FileContents
+      regex: "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+"
+  omit:
+    - type: Kubernetes
+      kubernetesResource:
+        kind: "Secret"
+    - type: Kubernetes
+      kubernetesResource:
+        kind: MachineConfig
+        apiVersion: machineconfiguration.openshift.io/v1

--- a/artifacts-collector/mgc-config-mustgather.yaml
+++ b/artifacts-collector/mgc-config-mustgather.yaml
@@ -12,12 +12,3 @@ config:
     - type: Regex
       target: FileContents
       regex: "(?i)(secret|httpSecret):\\s+[A-Za-z0-9+/=_-]{20,}"
-  omit:
-    - type: Kubernetes
-      kubernetesResource:
-        kind: MachineConfig
-        apiVersion: machineconfiguration.openshift.io/v1
-    - type: Kubernetes
-      kubernetesResource:
-        kind: ControllerConfig
-        apiVersion: machineconfiguration.openshift.io/v1

--- a/artifacts-collector/mgc-config-mustgather.yaml
+++ b/artifacts-collector/mgc-config-mustgather.yaml
@@ -6,6 +6,12 @@ config:
     - type: Regex
       target: FileContents
       regex: "eyJ[A-Za-z0-9_-]{10,}\\.eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]+"
+    - type: Regex
+      target: FileContents
+      regex: "Authorization:\\s+\\w+\\s+[A-Za-z0-9+/=_-]{20,}"
+    - type: Regex
+      target: FileContents
+      regex: "(?i)(secret|httpSecret):\\s+[A-Za-z0-9+/=_-]{20,}"
   omit:
     - type: Kubernetes
       kubernetesResource:
@@ -13,4 +19,8 @@ config:
     - type: Kubernetes
       kubernetesResource:
         kind: MachineConfig
+        apiVersion: machineconfiguration.openshift.io/v1
+    - type: Kubernetes
+      kubernetesResource:
+        kind: ControllerConfig
         apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
## Summary

- Embed [must-gather-clean](https://github.com/openshift/must-gather-clean) v0.0.5 in the artifacts-collector plugin image
- Run it against must-gather directory (omit Secrets/MachineConfig, redact sha256~ tokens and JWTs) before packing
- Run it against e2e metadata tar.gz archives (redact sha256~ tokens and JWTs) before final packing
- Falls back to existing sed-based cleaning if must-gather-clean fails

This prevents leaktk-gcs-filter from removing OPCT CI archives from GCS. The bulk of findings (3070 of 3157) are sha256~ OAuth tokens inside `artifacts_e2e-metadata-*.tar.gz` from openshift-tests output.

Verified locally: must-gather-clean with regex config reduces sha256~ findings in e2e metadata from 1212 to 0.

Related: redhat-openshift-ecosystem/opct#223 (non-nested scanner improvements, defense in depth)

## Test plan
- [ ] Build artifacts-collector image with changes
- [ ] Run must-gather-clean against extracted e2e metadata, confirm sha256~ count drops to 0
- [ ] Run must-gather-clean against extracted must-gather, confirm Secrets/MachineConfig omitted
- [ ] Run leaktk scan against cleaned archive, confirm 0 findings
- [ ] Full OPCT run on a cluster to verify no regressions

/cc @mtulio

🤖 Generated with [Claude Code](https://claude.com/claude-code)