### PR TITLE
OPCT-428: add mco-sanitize to clean machineconfig secrets in must-gather

### DIFF
--- a/artifacts-collector/Containerfile
+++ b/artifacts-collector/Containerfile
@@ -11,7 +11,7 @@ FROM quay.io/fedora/fedora-minimal:41 AS mco-sanitize
 ARG TARGETARCH=amd64
 RUN microdnf install -y curl && \
     set -euo pipefail && \
-    MCO_ARCH=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "${TARGETARCH}") && \
+    MCO_ARCH=$(case "${TARGETARCH}" in amd64) echo "x86_64";; arm64) echo "aarch64";; *) echo "${TARGETARCH}";; esac) && \
     curl -sSLf -o /usr/local/bin/mco-sanitize \
         "https://openshift-mirror-list.ci-systems.workers.dev/pub/ci/${MCO_ARCH}/mco-sanitize/mco-sanitize" && \
     chmod +x /usr/local/bin/mco-sanitize

--- a/artifacts-collector/Containerfile
+++ b/artifacts-collector/Containerfile
@@ -7,6 +7,15 @@ FROM ${PLUGIN_REPO}:${BUILD_VERSION} AS plugin
 
 FROM quay.io/opct/tools:v0.5.0 AS tools
 
+FROM quay.io/fedora/fedora-minimal:41 AS mco-sanitize
+ARG TARGETARCH=amd64
+RUN microdnf install -y curl && \
+    set -euo pipefail && \
+    MCO_ARCH=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "${TARGETARCH}") && \
+    curl -sSLf -o /usr/local/bin/mco-sanitize \
+        "https://openshift-mirror-list.ci-systems.workers.dev/pub/ci/${MCO_ARCH}/mco-sanitize/mco-sanitize" && \
+    chmod +x /usr/local/bin/mco-sanitize
+
 FROM quay.io/fedora/fedora-minimal:41 AS mgc
 ARG MGC_VERSION=0.0.5
 ARG TARGETARCH=amd64
@@ -36,6 +45,7 @@ COPY --from=tools /usr/bin/oc /usr/bin/oc
 COPY --from=tools /usr/bin/jq /usr/bin/jq
 COPY --from=tools /usr/bin/camgi /usr/bin/camgi
 COPY --from=mgc /usr/local/bin/must-gather-clean /usr/bin/must-gather-clean
+COPY --from=mco-sanitize /usr/local/bin/mco-sanitize /usr/bin/mco-sanitize
 
 # plugin openshift-tests must be built first (dependency)
 COPY --from=plugin /usr/bin/openshift-tests-plugin /usr/bin/openshift-tests-plugin

--- a/artifacts-collector/Containerfile
+++ b/artifacts-collector/Containerfile
@@ -7,15 +7,6 @@ FROM ${PLUGIN_REPO}:${BUILD_VERSION} AS plugin
 
 FROM quay.io/opct/tools:v0.5.0 AS tools
 
-FROM quay.io/fedora/fedora-minimal:41 AS mco-sanitize
-ARG TARGETARCH=amd64
-RUN microdnf install -y curl && \
-    set -euo pipefail && \
-    MCO_ARCH=$(case "${TARGETARCH}" in amd64) echo "x86_64";; arm64) echo "aarch64";; *) echo "${TARGETARCH}";; esac) && \
-    curl -sSLf -o /usr/local/bin/mco-sanitize \
-        "https://openshift-mirror-list.ci-systems.workers.dev/pub/ci/${MCO_ARCH}/mco-sanitize/mco-sanitize" && \
-    chmod +x /usr/local/bin/mco-sanitize
-
 FROM quay.io/fedora/fedora-minimal:41 AS mgc
 ARG MGC_VERSION=0.0.5
 ARG TARGETARCH=amd64
@@ -45,7 +36,7 @@ COPY --from=tools /usr/bin/oc /usr/bin/oc
 COPY --from=tools /usr/bin/jq /usr/bin/jq
 COPY --from=tools /usr/bin/camgi /usr/bin/camgi
 COPY --from=mgc /usr/local/bin/must-gather-clean /usr/bin/must-gather-clean
-COPY --from=mco-sanitize /usr/local/bin/mco-sanitize /usr/bin/mco-sanitize
+COPY --from=tools /usr/bin/mco-sanitize /usr/bin/mco-sanitize
 
 # plugin openshift-tests must be built first (dependency)
 COPY --from=plugin /usr/bin/openshift-tests-plugin /usr/bin/openshift-tests-plugin

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -37,6 +37,14 @@ clean_must_gather() {
     sed -i 's/\(internalRegistryPullSecret:\s*\).*/\1"<sensitive>"/' \
         ${MUST_GATHER_DIR}/*/cluster-scoped-resources/machineconfiguration.openshift.io/controllerconfigs/machine-config-controller.yaml >/dev/null 2>&1
 
+    # sanitize MCO resources (machineconfigs contain pull secrets and JWTs in ignition config)
+    os_log_info "[executor][PluginID#${PLUGIN_ID}] Running mco-sanitize on must-gather"
+    if ! mco-sanitize --input="${MUST_GATHER_DIR}"; then
+        os_log_info "[executor][PluginID#${PLUGIN_ID}] mco-sanitize failed, falling back to manual redaction"
+        find "${MUST_GATHER_DIR}" -type f -path '*/cluster-scoped-resources/machineconfiguration.openshift.io/*' \
+            -exec sh -c 'echo "REDACTED" > "$1" && mv "$1" "$1.redacted"' _ {} \;
+    fi
+
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Cleaning must-gather with must-gather-clean"
     local mg_clean_dir="${MUST_GATHER_DIR}-clean"
     must-gather-clean -c /plugin/mgc-config-mustgather.yaml \

--- a/artifacts-collector/collector.sh
+++ b/artifacts-collector/collector.sh
@@ -41,7 +41,7 @@ clean_must_gather() {
     os_log_info "[executor][PluginID#${PLUGIN_ID}] Running mco-sanitize on must-gather"
     if ! mco-sanitize --input="${MUST_GATHER_DIR}"; then
         os_log_info "[executor][PluginID#${PLUGIN_ID}] mco-sanitize failed, falling back to manual redaction"
-        find "${MUST_GATHER_DIR}" -type f -path '*/cluster-scoped-resources/machineconfiguration.openshift.io/*' \
+        find "${MUST_GATHER_DIR}" -type f -path '*/cluster-scoped-resources/machineconfiguration.openshift.io/*' ! -name '*.redacted' \
             -exec sh -c 'echo "REDACTED" > "$1" && mv "$1" "$1.redacted"' _ {} \;
     fi
 

--- a/artifacts-collector/mgc-config-mustgather.yaml
+++ b/artifacts-collector/mgc-config-mustgather.yaml
@@ -12,3 +12,6 @@ config:
     - type: Regex
       target: FileContents
       regex: "(?i)(secret|httpSecret):\\s+[A-Za-z0-9+/=_-]{20,}"
+    - type: Regex
+      target: FileContents
+      regex: "(?i)token:\\s+[A-Za-z0-9+/=_-]{20,}"

--- a/artifacts-collector/mgc-config-mustgather.yaml
+++ b/artifacts-collector/mgc-config-mustgather.yaml
@@ -12,6 +12,3 @@ config:
     - type: Regex
       target: FileContents
       regex: "(?i)(secret|httpSecret):\\s+[A-Za-z0-9+/=_-]{20,}"
-    - type: Regex
-      target: FileContents
-      regex: "(?i)token:\\s+[A-Za-z0-9+/=_-]{20,}"

--- a/tools/Containerfile
+++ b/tools/Containerfile
@@ -54,4 +54,9 @@ COPY --from=clients /clients/oc /usr/bin/oc
 COPY --from=clients /clients/jq /usr/bin/jq
 COPY --from=clients /clients/camgi /usr/bin/camgi
 
+RUN MCO_ARCH=$(case "${TARGETARCH}" in amd64) echo "x86_64";; arm64) echo "aarch64";; *) echo "${TARGETARCH}";; esac) && \
+    curl -sSLf -o /usr/bin/mco-sanitize \
+        "https://openshift-mirror-list.ci-systems.workers.dev/pub/ci/${MCO_ARCH}/mco-sanitize/mco-sanitize" && \
+    chmod +x /usr/bin/mco-sanitize
+
 RUN ln -svf /usr/bin/oc /usr/bin/kubectl


### PR DESCRIPTION
## Summary

- Add mco-sanitize to the artifacts-collector plugin to redact pull secrets and JWTs from machineconfig ignition configs in must-gather
- Same tool CI gather-must-gather step uses

## Root Cause

leaktk-gcs-filter was redacting the entire OPCT archive (76 bytes) because machineconfigs (00-master.yaml, 00-worker.yaml) inside the OPCT must-gather contained real pull secrets and JWTs in the ignition config.

CI standalone must-gather.tar in the same job was NOT redacted because the gather-must-gather step runs mco-sanitize after collection. OPCT artifacts-collector was missing this step.

Evidence from same CI job (2076734326464057344):
- Standalone must-gather 00-master.yaml (17 KB): _REDACTED: This field has been redacted
- OPCT must-gather 00-master.yaml (151 KB): real auths with base64 registry credentials

leaktk self-service form confirmed 25 findings, 6 from machineconfigs (the trigger).

## Changes

### artifacts-collector/Containerfile
- New build stage to download mco-sanitize binary (16 MB) from CI mirror
- COPY into main image at /usr/bin/mco-sanitize

### artifacts-collector/collector.sh
- Run mco-sanitize on must-gather directory after sed and before must-gather-clean
- Fallback to manual REDACTED if mco-sanitize fails (same pattern as CI)

## Verification

Needs integration test: run OPCT with this image, retrieve archive, run leaktk scan - machineconfig findings should be 0.

Jira: https://redhat.atlassian.net/browse/OPCT-428