### PR TITLE
OPCT-428: make mco-sanitize COPY optional for arm64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -92,6 +92,9 @@ function build_tools() {
         oc_archive="openshift-client-linux.tar.gz"
         oc_url="https://mirror.openshift.com/pub/openshift-v4/${TARGET_ARCH}/clients/ocp/${ocp_version}/${oc_archive}"
 
+        mco_arch=$([ "${TARGET_ARCH}" = "amd64" ] && echo "x86_64" || echo "${TARGET_ARCH}")
+        mco_sanitize_url="https://openshift-mirror-list.ci-systems.workers.dev/pub/ci/${mco_arch}/mco-sanitize/mco-sanitize"
+
         podman build --platform "${platform}" \
             --manifest "${manifest}" \
             -f "${build_root}"/Containerfile \
@@ -101,6 +104,7 @@ function build_tools() {
             --build-arg=CAMGI_TAR="${camgi_archive}" \
             --build-arg=OC_TAR="${oc_archive}" \
             --build-arg=OC_URL="${oc_url}" \
+            --build-arg=MCO_SANITIZE_URL="${mco_sanitize_url}" \
             --build-arg=QUAY_EXPIRATION="${IMAGE_EXPIRE_TIME}" \
             --build-arg=TARGETPLATFORM="${platform}" \
             --build-arg=TARGETARCH="${TARGET_ARCH}" \

--- a/tools/Containerfile
+++ b/tools/Containerfile
@@ -54,13 +54,8 @@ COPY --from=clients /clients/oc /usr/bin/oc
 COPY --from=clients /clients/jq /usr/bin/jq
 COPY --from=clients /clients/camgi /usr/bin/camgi
 
-RUN MCO_ARCH=$(case "${TARGETARCH}" in amd64) echo "x86_64";; *) echo "";; esac) && \
-    if [ -n "${MCO_ARCH}" ]; then \
-        curl -sSLf -o /usr/bin/mco-sanitize \
-            "https://openshift-mirror-list.ci-systems.workers.dev/pub/ci/${MCO_ARCH}/mco-sanitize/mco-sanitize" && \
-        chmod +x /usr/bin/mco-sanitize; \
-    else \
-        echo "mco-sanitize not available for ${TARGETARCH}, skipping"; \
-    fi
+ARG MCO_SANITIZE_URL=TBD
+ADD ${MCO_SANITIZE_URL} /usr/bin/mco-sanitize
+RUN chmod +x /usr/bin/mco-sanitize
 
 RUN ln -svf /usr/bin/oc /usr/bin/kubectl


### PR DESCRIPTION
Fix CI release-latest build failure on arm64. The tools:v0.6.0 arm64 image does not have mco-sanitize (not published for aarch64). Use wildcard glob so COPY succeeds silently on arm64. collector.sh already handles the missing binary with manual redaction fallback.

Fixes: https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/actions/runs/29516430669