### PR TITLE
OPCT-454: remove --file workaround for kube-conformance plugin

### DIFF
--- a/openshift-tests-plugin/pkg/plugin/plugin.go
+++ b/openshift-tests-plugin/pkg/plugin/plugin.go
@@ -284,25 +284,6 @@ func (p *Plugin) Initialize() error {
 	}
 	log.Infof("Total test count: %d", len(p.SuiteTests))
 
-	// For kube-conformance plugin (10) on OCP 4.20+, use the extracted conformance
-	// test list to run only conformance tests via --file flag. On 4.20+ the suite
-	// kubernetes/conformance was removed from openshift-tests, requiring extraction
-	// On 4.20+, conformance tests are extracted from k8s-tests-ext and run via --file.
-	// The suite name is preserved from DEFAULT_SUITE_NAME (kubernetes/conformance/parallel)
-	// so openshift-tests filters tests consistently with the suite definition.
-	// On pre-4.20, DEFAULT_SUITE_NAME is "kubernetes/conformance" which works directly.
-	if p.id == PluginId10 {
-		suiteName := os.Getenv("DEFAULT_SUITE_NAME")
-		if suiteName != "" && suiteName != "kubernetes/conformance" {
-			k8sConformanceList := "/tmp/shared/k8s-conformance-tests.list"
-			if info, err := os.Stat(k8sConformanceList); err == nil && info.Size() > 0 {
-				log.Infof("Setting run file for plugin %s using extracted conformance list %s", p.name, k8sConformanceList)
-				p.OTRunner.File = k8sConformanceList
-				p.OTRunner.SuiteName = suiteName
-			}
-		}
-	}
-
 	if err := p.InitalizeDevelMode(); err != nil {
 		log.Errorf("error setting up devel mode: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Remove the `--file` workaround for kube-conformance plugin (plugin 10) added in PR #84/#86
- Suite name resolution now works correctly after upstream fixes landed and were backported (origin#31261, k8s#2694, and backports to 4.21/4.22)
- Fixes upgrade jobs failing with 0/414 tests since June 2026 due to version skew between pre/post-upgrade binaries

## Context
- Tracked under [OPCT-401](https://redhat.atlassian.net/browse/OPCT-401)
- Slack thread: https://redhat-internal.slack.com/archives/C04HTQ7A7EX/p1785951340628179
- The `--file` flag was a temporary workaround while `kubernetes/conformance` suite was unavailable on OCP 4.20+. Now that upstream backports are merged across 4.21/4.22/5.0, the suite name drives test selection correctly and `--file` is unnecessary

## Test plan
- [ ] CI periodic upgrade job passes (4.21-upgrade-from-4.20, 4.22-upgrade-from-4.21)
- [ ] Non-upgrade jobs remain unaffected (4.20, 4.21, 4.22, 5.0 aws-ccm)
- [ ] kube-conformance test count matches expected (~419-436 tests)